### PR TITLE
feat(admin/setup): Automatically log in newly created admin

### DIFF
--- a/app/server/mutations/admin/setup.ts
+++ b/app/server/mutations/admin/setup.ts
@@ -1,8 +1,10 @@
 import {makeDomainFunction} from "domain-functions"
 
 import {AdminSetupInput} from "../../zod/user/AdminSetupInput.js"
-import {User} from "../../db/entities.js"
+import {serializeCookie} from "../../lib/auth/cookie.js"
+import {lucia} from "../../lib/auth/lucia.js"
 import {withOrm} from "../../lib/db/orm.js"
+import {User} from "../../db/entities.js"
 
 /**
  * Creates admin account
@@ -12,5 +14,10 @@ export const setup = makeDomainFunction(AdminSetupInput)(
     const user = new User(input)
 
     await orm.em.persistAndFlush(user)
+
+    const session = await lucia.createSession(user.id, {})
+    const cookie = await serializeCookie(session.id)
+
+    return new Headers([["set-cookie", cookie]])
   })
 )


### PR DESCRIPTION
### Details

This PR improves admin onboarding by introducing auto login.

### Changes

- [x] Add auto login after admin account creation;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] ~~I have added changesets <!-- optional -->~~
- [x] ~~I have brought tests <!-- if necessary -->~~
