### PR TITLE
feat(posts): Add post view

### DIFF
--- a/app/components/common/Blockquote.tsx
+++ b/app/components/common/Blockquote.tsx
@@ -1,0 +1,21 @@
+import type {ComponentPropsWithoutRef, ElementRef} from "react"
+import {forwardRef} from "react"
+
+import {cn} from "../../lib/utils.js"
+
+export type BlockquoteRef = ElementRef<"blockquote">
+
+export type BlockquoteProps = ComponentPropsWithoutRef<"blockquote">
+
+export const Blockquote = forwardRef<BlockquoteRef, BlockquoteProps>(
+  ({className, children, ...props}, ref) => (
+    <blockquote
+      {...props}
+
+      ref={ref}
+      className={cn("my-1 border-l-2 pl-6 italic", className)}
+    >
+      {children}
+    </blockquote>
+  )
+)

--- a/app/components/common/Code.tsx
+++ b/app/components/common/Code.tsx
@@ -1,0 +1,16 @@
+import type {ComponentPropsWithoutRef, ElementRef} from "react"
+import {forwardRef} from "react"
+
+import {cn} from "../../lib/utils.js"
+
+export type CodeRef = ElementRef<"code">
+
+export type CodeProps = ComponentPropsWithoutRef<"code">
+
+export const Code = forwardRef<CodeRef, CodeProps>(
+  ({className, children, ...props}, ref) => (
+    <code {...props} ref={ref} className={cn("whitespace-pre-wrap rounded-md bg-muted px-[0.3em] py-[0.2em] font-mono text-sm", className)}>
+      {children}
+    </code>
+  )
+)

--- a/app/components/common/Heading.tsx
+++ b/app/components/common/Heading.tsx
@@ -1,0 +1,49 @@
+import {Box, withRef} from "@udecode/plate-common"
+import {cva} from "class-variance-authority"
+import {withVariants} from "@udecode/cn"
+
+import {
+  OHeadingLevels
+} from "../../server/zod/plate/common/HeadingLevels.js"
+
+const headingVariants = cva("", {
+  variants: {
+    variant: {
+      h1: "mb-1 mt-[2em] font-heading text-4xl font-bold",
+      h2: "mb-px mt-[1.4em] font-heading text-2xl font-semibold tracking-tight",
+      h3: "mb-px mt-[1em] font-heading text-xl font-semibold tracking-tight",
+      h4: "mt-[0.75em] font-heading text-lg font-semibold tracking-tight",
+      h5: "mt-[0.75em] text-lg font-semibold tracking-tight",
+      h6: "mt-[0.75em] text-base font-semibold tracking-tight"
+    } satisfies Record<OHeadingLevels, string>,
+    isFirstBlock: {
+      true: "mt-0",
+      false: ""
+    }
+  }
+})
+
+const HeadingElementVariants = withVariants(Box, headingVariants, [
+  "isFirstBlock",
+  "variant"
+])
+
+export const Heading = withRef<typeof HeadingElementVariants>(
+  ({variant, children, ...props}, ref) => {
+    const Element = variant ?? "h1"
+
+    return (
+      <HeadingElementVariants
+        {...props}
+
+        ref={ref}
+        variant={variant}
+        asChild
+      >
+        <Element>
+          {children}
+        </Element>
+      </HeadingElementVariants>
+    )
+  }
+)

--- a/app/components/common/Heading.tsx
+++ b/app/components/common/Heading.tsx
@@ -15,16 +15,11 @@ const headingVariants = cva("", {
       h4: "mt-[0.75em] font-heading text-lg font-semibold tracking-tight",
       h5: "mt-[0.75em] text-lg font-semibold tracking-tight",
       h6: "mt-[0.75em] text-base font-semibold tracking-tight"
-    } satisfies Record<OHeadingLevels, string>,
-    isFirstBlock: {
-      true: "mt-0",
-      false: ""
-    }
+    } satisfies Record<OHeadingLevels, string>
   }
 })
 
 const HeadingElementVariants = withVariants(Box, headingVariants, [
-  "isFirstBlock",
   "variant"
 ])
 

--- a/app/components/common/Kbd.tsx
+++ b/app/components/common/Kbd.tsx
@@ -1,0 +1,16 @@
+import type {ComponentPropsWithoutRef, ElementRef} from "react"
+import {forwardRef} from "react"
+
+import {cn} from "../../lib/utils.js"
+
+export type KbdRef = ElementRef<"kbd">
+
+export type KbfProps = ComponentPropsWithoutRef<"kbd">
+
+export const Kbd = forwardRef<KbdRef, KbfProps>(
+  ({className, children, ...props}, ref) => (
+    <kbd {...props} ref={ref} className={cn("rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-sm shadow-[rgba(255,_255,_255,_0.1)_0px_0.5px_0px_0px_inset,_rgb(248,_249,_250)_0px_1px_5px_0px_inset,_rgb(193,_200,_205)_0px_0px_0px_0.5px,_rgb(193,_200,_205)_0px_2px_1px_-1px,_rgb(193,_200,_205)_0px_1px_0px_0px] dark:shadow-[rgba(255,_255,_255,_0.1)_0px_0.5px_0px_0px_inset,_rgb(26,_29,_30)_0px_1px_5px_0px_inset,_rgb(76,_81,_85)_0px_0px_0px_0.5px,_rgb(76,_81,_85)_0px_2px_1px_-1px,_rgb(76,_81,_85)_0px_1px_0px_0px]", className)}>
+      {children}
+    </kbd>
+  )
+)

--- a/app/components/common/Link.tsx
+++ b/app/components/common/Link.tsx
@@ -1,0 +1,21 @@
+import type {ComponentPropsWithoutRef, ElementRef} from "react"
+import {forwardRef} from "react"
+
+import {cn} from "../../lib/utils.js"
+
+export type LinkRef = ElementRef<"a">
+
+export type LinkProps = ComponentPropsWithoutRef<"a">
+
+export const Link = forwardRef<LinkRef, LinkProps>(
+  ({className, children, ...props}, ref) => (
+    <a
+      {...props}
+
+      ref={ref}
+      className={cn("font-medium text-primary underline decoration-primary underline-offset-4", className)}
+    >
+      {children}
+    </a>
+  )
+)

--- a/app/components/editors/post/plugins.ts
+++ b/app/components/editors/post/plugins.ts
@@ -138,7 +138,11 @@ export const plugins = createPlugins(
         ]
       }
     }),
-    createNodeIdPlugin(),
+    createNodeIdPlugin({
+      options: {
+        idCreator: () => crypto.randomUUID()
+      }
+    }),
     createResetNodePlugin({
       options: {
         rules: [

--- a/app/components/plate-ui/BlockquoteElement.tsx
+++ b/app/components/plate-ui/BlockquoteElement.tsx
@@ -1,6 +1,7 @@
 import {PlateElement} from "@udecode/plate-common"
 import {cn, withRef} from "@udecode/cn"
 
+// TODO: Use common element for component
 export const BlockquoteElement = withRef<typeof PlateElement>(
   ({className, children, ...props}, ref) => (
     <PlateElement

--- a/app/components/plate-ui/CodeLeaf.tsx
+++ b/app/components/plate-ui/CodeLeaf.tsx
@@ -1,18 +1,16 @@
 import {PlateLeaf} from "@udecode/plate-common"
-import {cn, withRef} from "@udecode/cn"
+import {withRef} from "@udecode/cn"
+
+import {Code} from "../common/Code.jsx"
 
 export const CodeLeaf = withRef<typeof PlateLeaf>(
-  ({className, children, ...props}, ref) => (
+  ({children, ...props}, ref) => (
     <PlateLeaf
       ref={ref}
       asChild
-      className={cn(
-        "whitespace-pre-wrap rounded-md bg-muted px-[0.3em] py-[0.2em] font-mono text-sm",
-        className
-      )}
       {...props}
     >
-      <code>{children}</code>
+      <Code>{children}</Code>
     </PlateLeaf>
   )
 )

--- a/app/components/plate-ui/HeadingElement.tsx
+++ b/app/components/plate-ui/HeadingElement.tsx
@@ -2,16 +2,10 @@ import {PlateElement} from "@udecode/plate-common"
 import {withRef, withVariants} from "@udecode/cn"
 import {cva} from "class-variance-authority"
 
+import {Heading} from "../common/Heading.jsx"
+
 const headingVariants = cva("", {
   variants: {
-    variant: {
-      h1: "mb-1 mt-[2em] font-heading text-4xl font-bold",
-      h2: "mb-px mt-[1.4em] font-heading text-2xl font-semibold tracking-tight",
-      h3: "mb-px mt-[1em] font-heading text-xl font-semibold tracking-tight",
-      h4: "mt-[0.75em] font-heading text-lg font-semibold tracking-tight",
-      h5: "mt-[0.75em] text-lg font-semibold tracking-tight",
-      h6: "mt-[0.75em] text-base font-semibold tracking-tight"
-    },
     isFirstBlock: {
       true: "mt-0",
       false: ""
@@ -20,27 +14,23 @@ const headingVariants = cva("", {
 })
 
 const HeadingElementVariants = withVariants(PlateElement, headingVariants, [
-  "isFirstBlock",
-  "variant"
+  "isFirstBlock"
 ])
 
 export const HeadingElement = withRef<typeof HeadingElementVariants>(
-  ({variant, children, ...props}, ref) => {
+  ({children, ...props}, ref) => {
     const {element, editor} = props
-
-    const Element = variant ?? "h1"
 
     return (
       <HeadingElementVariants
         ref={ref}
         asChild
-        variant={variant}
         isFirstBlock={element === editor.children[0]}
         {...props}
       >
-        <Element>
+        <Heading>
           {children}
-        </Element>
+        </Heading>
       </HeadingElementVariants>
     )
   }

--- a/app/components/plate-ui/KbdLeaf.tsx
+++ b/app/components/plate-ui/KbdLeaf.tsx
@@ -1,18 +1,16 @@
 import {PlateLeaf} from "@udecode/plate-common"
-import {cn, withRef} from "@udecode/cn"
+import {withRef} from "@udecode/cn"
+
+import {Kbd} from "../common/Kbd.jsx"
 
 export const KbdLeaf = withRef<typeof PlateLeaf>(
-  ({className, children, ...props}, ref) => (
+  ({children, ...props}, ref) => (
     <PlateLeaf
       ref={ref}
       asChild
-      className={cn(
-        "rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-sm shadow-[rgba(255,_255,_255,_0.1)_0px_0.5px_0px_0px_inset,_rgb(248,_249,_250)_0px_1px_5px_0px_inset,_rgb(193,_200,_205)_0px_0px_0px_0.5px,_rgb(193,_200,_205)_0px_2px_1px_-1px,_rgb(193,_200,_205)_0px_1px_0px_0px] dark:shadow-[rgba(255,_255,_255,_0.1)_0px_0.5px_0px_0px_inset,_rgb(26,_29,_30)_0px_1px_5px_0px_inset,_rgb(76,_81,_85)_0px_0px_0px_0.5px,_rgb(76,_81,_85)_0px_2px_1px_-1px,_rgb(76,_81,_85)_0px_1px_0px_0px]",
-        className
-      )}
       {...props}
     >
-      <kbd>{children}</kbd>
+      <Kbd>{children}</Kbd>
     </PlateLeaf>
   )
 )

--- a/app/components/plate-ui/LinkElement.tsx
+++ b/app/components/plate-ui/LinkElement.tsx
@@ -2,10 +2,12 @@
 
 import {PlateElement, useElement} from "@udecode/plate-common"
 import {TLinkElement, useLink} from "@udecode/plate-link"
-import {cn, withRef} from "@udecode/cn"
+import {withRef} from "@udecode/cn"
+
+import {Link} from "../common/Link.jsx"
 
 export const LinkElement = withRef<typeof PlateElement>(
-  ({className, children, ...props}, ref) => {
+  ({children, ...props}, ref) => {
     const element = useElement<TLinkElement>()
     const {props: linkProps} = useLink({element})
 
@@ -13,14 +15,12 @@ export const LinkElement = withRef<typeof PlateElement>(
       <PlateElement
         ref={ref}
         asChild
-        className={cn(
-          "font-medium text-primary underline decoration-primary underline-offset-4",
-          className
-        )}
         {...(linkProps as any)}
         {...props}
       >
-        <a>{children}</a>
+        <Link>
+          {children}
+        </Link>
       </PlateElement>
     )
   }

--- a/app/components/slate-view/elements/Anchor.tsx
+++ b/app/components/slate-view/elements/Anchor.tsx
@@ -1,0 +1,13 @@
+import {isLink, createElementTransform} from "slate-to-react"
+
+import {Link} from "../../common/Link.jsx"
+
+export const Anchor = createElementTransform(
+  isLink,
+
+  ({key, attributes, element, children}) => (
+    <Link {...attributes} key={key} href={element.url}>
+      {children}
+    </Link>
+  )
+)

--- a/app/components/slate-view/elements/Blockquote.tsx
+++ b/app/components/slate-view/elements/Blockquote.tsx
@@ -1,0 +1,13 @@
+import {isBlockquote, createElementTransform} from "slate-to-react"
+
+import {Blockquote as CommonBlockquote} from "../../common/Blockquote.jsx"
+
+export const Blockquote = createElementTransform(
+  isBlockquote,
+
+  ({key, attributes, children}) => (
+    <CommonBlockquote {...attributes} key={key}>
+      {children}
+    </CommonBlockquote>
+  )
+)

--- a/app/components/slate-view/elements/Heading.tsx
+++ b/app/components/slate-view/elements/Heading.tsx
@@ -1,0 +1,13 @@
+import {isHeading, createElementTransform} from "slate-to-react"
+
+import {Heading as CommonHeading} from "../../common/Heading.jsx"
+
+export const Heading = createElementTransform(
+  isHeading,
+
+  ({key, element, attributes, children}) => (
+    <CommonHeading {...attributes} key={key} variant={element.type}>
+      {children}
+    </CommonHeading>
+  )
+)

--- a/app/components/slate-view/leaves/Text.tsx
+++ b/app/components/slate-view/leaves/Text.tsx
@@ -45,7 +45,7 @@ export const Text = createLeafTransform(
     }
 
     if ("kbd" in leaf) {
-      return combineMarks([...nodes, Code], {...props, leaf})
+      return combineMarks([...nodes, Kbd], {...props, leaf})
     }
 
     if ("bold" in leaf) {

--- a/app/components/slate-view/leaves/Text.tsx
+++ b/app/components/slate-view/leaves/Text.tsx
@@ -1,0 +1,75 @@
+import {createLeafNodeMatcher, createLeafTransform, LeafTransform} from "slate-to-react"
+import {createElement, ReactNode, FC, type ReactElement} from "react"
+
+import {OAnyText} from "../../../server/zod/plate/common/AnyText.js"
+
+import {Code} from "../../common/Code.jsx"
+import {Kbd} from "../../common/Kbd.jsx"
+
+type TextProps = Parameters<LeafTransform["transform"]>[0]
+
+type Nodes = Array<FC<any> | string>
+
+const combineMarks = (
+  nodes: Nodes,
+
+  {key, attributes, children}: TextProps
+) => nodes.reduce<ReactNode>(
+  (prev, next, index, {length}) => createElement(
+    next,
+
+    index + 1 === length ? {...attributes, key} : null,
+
+    prev
+  ),
+
+  children
+) as ReactElement
+
+export const isAnyText = createLeafNodeMatcher<OAnyText>(
+  (node): node is OAnyText => typeof node.text === "string"
+)
+
+export const Text = createLeafTransform(
+  isAnyText,
+
+  ({leaf, ...props}) => {
+    const nodes: Nodes = ["span"]
+
+    if (leaf.text === "") {
+      return combineMarks(nodes, {...props, leaf})
+    }
+
+    if ("code" in leaf) {
+      return combineMarks([...nodes, Code], {...props, leaf})
+    }
+
+    if ("kbd" in leaf) {
+      return combineMarks([...nodes, Code], {...props, leaf})
+    }
+
+    if ("bold" in leaf) {
+      nodes.push("strong")
+    }
+
+    if ("italic" in leaf) {
+      nodes.push("em")
+    }
+
+    if ("strikethrough" in leaf) {
+      nodes.push("s")
+    }
+
+    if ("underline" in leaf) {
+      nodes.push("u")
+    }
+
+    if ("subscript" in leaf) {
+      nodes.push("sub")
+    } else if ("superscript" in leaf) {
+      nodes.push("sup")
+    }
+
+    return combineMarks(nodes, {...props, leaf})
+  }
+)

--- a/app/routes/admin.posts.$date.$name.tsx
+++ b/app/routes/admin.posts.$date.$name.tsx
@@ -1,16 +1,13 @@
-import {useLoaderData} from "@remix-run/react"
-import type {FC} from "react"
+import type {BreadcrumbHandle} from "../components/Breadcrumbs.jsx"
+import {BreadcrumbPage} from "../components/ui/Breadcrumb.jsx"
 
-import {loader} from "./posts.$date.$name.jsx"
-
-export {loader, meta} from "./posts.$date.$name.jsx"
-
-const AdminPostViewPage: FC = () => {
-  const {title} = useLoaderData<typeof loader>()
-
-  return (
-    <div>{title}</div>
+export const handle: BreadcrumbHandle = {
+  breadcrumb: () => (
+    <BreadcrumbPage>
+      Post
+    </BreadcrumbPage>
   )
 }
 
-export default AdminPostViewPage
+// eslint-disable-next-line no-restricted-exports
+export {default, loader} from "./posts.$date.$name.jsx"

--- a/app/routes/posts.$date.$name.tsx
+++ b/app/routes/posts.$date.$name.tsx
@@ -1,5 +1,6 @@
 import type {LoaderFunctionArgs, MetaFunction} from "@remix-run/node"
 import {useLoaderData} from "@remix-run/react"
+import {SlateView} from "slate-to-react"
 import {json} from "@remix-run/node"
 import type {FC} from "react"
 
@@ -38,9 +39,7 @@ const PostViewPage: FC = () => {
   const post = useLoaderData<typeof loader>()
 
   return (
-    <div>
-      {post.title}
-    </div>
+    <SlateView nodes={post.content} />
   )
 }
 

--- a/app/routes/posts.$date.$name.tsx
+++ b/app/routes/posts.$date.$name.tsx
@@ -7,6 +7,12 @@ import type {FC} from "react"
 import {Post} from "../server/db/entities.js"
 import {withOrm} from "../server/lib/db/orm.js"
 
+import {Anchor} from "../components/slate-view/elements/Anchor.jsx"
+import {Blockquote} from "../components/slate-view/elements/Blockquote.jsx"
+import {Heading} from "../components/slate-view/elements/Heading.jsx"
+
+import {Text} from "../components/slate-view/leaves/Text.jsx"
+
 interface Params {
   date: string
   name: string
@@ -39,7 +45,13 @@ const PostViewPage: FC = () => {
   const post = useLoaderData<typeof loader>()
 
   return (
-    <SlateView nodes={post.content} />
+    <SlateView
+      nodes={post.content}
+      transforms={{
+        elements: [Anchor, Heading, Blockquote],
+        leaves: [Text]
+      }}
+    />
   )
 }
 

--- a/app/routes/posts.tsx
+++ b/app/routes/posts.tsx
@@ -1,0 +1,10 @@
+import {Outlet} from "@remix-run/react"
+import type {FC} from "react"
+
+const PostsLayout: FC = () => (
+  <div className="w-full p-5 laptop:max-w-post laptop:mx-auto">
+    <Outlet />
+  </div>
+)
+
+export default PostsLayout

--- a/app/server/zod/plate/common/Anchor.ts
+++ b/app/server/zod/plate/common/Anchor.ts
@@ -7,7 +7,10 @@ import {createElementType} from "../utils/createElementType.js"
 
 export const ElementAnchor = z.literal(ELEMENT_LINK)
 
-export const Anchor = createElementType(ElementAnchor, z.array(Text).nonempty())
+export const Anchor = createElementType(
+  ElementAnchor,
+  z.array(Text).nonempty()
+).extend({url: z.string().url()})
 
 export type IAnchor = z.input<typeof Anchor>
 

--- a/app/server/zod/plate/common/AnyText.ts
+++ b/app/server/zod/plate/common/AnyText.ts
@@ -5,7 +5,8 @@ import {EmptyText} from "./EmptyText.js"
 import {PlainText} from "./PlainText.js"
 import {InlineCodeText} from "./InlineCodeText.js"
 
-export const AnyText = z.union([EmptyText, PlainText, InlineCodeText, RichText])
+// ! FIXME: Fix formatting validation - all marks are getting removed for some reason
+export const AnyText = z.union([EmptyText, InlineCodeText, RichText, PlainText])
 
 export type IAnyText = z.input<typeof AnyText>
 

--- a/app/server/zod/plate/common/WithId.ts
+++ b/app/server/zod/plate/common/WithId.ts
@@ -3,7 +3,19 @@ import {z} from "zod"
 import {ID} from "../../common/ID.js"
 
 export const WithId = z.object({
-  id: ID.default(() => crypto.randomUUID())
+  id: z.string().optional().transform(async value => {
+    if (!value) {
+      return crypto.randomUUID()
+    }
+
+    const result = await ID.safeParseAsync(value)
+
+    if (result.success) {
+      return result.data
+    }
+
+    return crypto.randomUUID()
+  })
 })
 
 export type IWithId = z.input<typeof WithId>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,13 +6,13 @@ import animate from "tailwindcss-animate"
 const mobile = "450px"
 const laptop = "1024px"
 const desktop = "1280px"
+const post = "800px"
 
 const dynamicScreenWidth = "100dvw"
 const dynamicScreenHeight = "100dvh"
 const dynamicScreenKey = "dynamic-screen"
 
 export default {
-  // darkMode: ["class"],
   content: ["**/*.tsx"],
   theme: {
     container: {
@@ -35,13 +35,15 @@ export default {
         [dynamicScreenKey]: dynamicScreenWidth,
         mobile,
         laptop,
-        desktop
+        desktop,
+        post
       },
       maxWidth: {
         [dynamicScreenKey]: dynamicScreenWidth,
         mobile,
         laptop,
-        desktop
+        desktop,
+        post
       },
       minHeight: {
         [dynamicScreenKey]: dynamicScreenHeight


### PR DESCRIPTION
### Details

This PR adds post view using [slate-to-react](https://github.com/octet-stream/slate-to-react) components for both guests and admin.

### Changes

- [x] Add post view;
- [x] Add `post` width to tailwincss config set to 800px;
- [x] Add matchers for elements and leaves with plate-ui components;
- [x] Add breadcrumbs for post view in admin panel;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] ~~I have added changesets <!-- optional -->~~
- [x] ~~I have brought tests <!-- if necessary -->~~
