### PR TITLE
feat(posts/admin): Add group for admin dashboard route and posts list

### DIFF
--- a/app/routes/admin._index.tsx
+++ b/app/routes/admin._index.tsx
@@ -1,6 +1,0 @@
-// TODO: Replace loader on this page with it's own when I add filters
-export {loader} from "./_blog._index/route.jsx"
-
-const AdminPage = () => <div>Admin dashboard will be here</div>
-
-export default AdminPage

--- a/app/routes/admin._index/components/NoPosts.tsx
+++ b/app/routes/admin._index/components/NoPosts.tsx
@@ -1,0 +1,9 @@
+import type {FC} from "react"
+
+export const NoPosts: FC = () => (
+  <div className="flex flex-1 justify-center items-center">
+    <p className="text-sm text-muted-foreground">
+      There are no posts yet
+    </p>
+  </div>
+)

--- a/app/routes/admin._index/components/PostItem.tsx
+++ b/app/routes/admin._index/components/PostItem.tsx
@@ -1,0 +1,14 @@
+import {Link} from "@remix-run/react"
+import type {FC} from "react"
+
+import {usePostContext} from "../contexts/PostContext.jsx"
+
+export const PostItem: FC = () => {
+  const {title, slug} = usePostContext()
+
+  return (
+    <Link to={`/admin/posts/${slug}`}>
+      {title}
+    </Link>
+  )
+}

--- a/app/routes/admin._index/components/PostsList.tsx
+++ b/app/routes/admin._index/components/PostsList.tsx
@@ -1,0 +1,21 @@
+import type {FC} from "react"
+
+import {usePostsContext} from "../contexts/PostsContext.jsx"
+import {PostContext} from "../contexts/PostContext.jsx"
+import {PostItem} from "./PostItem.jsx"
+
+export const PostsList: FC = () => {
+  const posts = usePostsContext()
+
+  return (
+    <ul className="flex flex-1 flex-col gap-3">
+      {posts.list.map(post => (
+        <li key={post.id}>
+          <PostContext.Provider value={post}>
+            <PostItem />
+          </PostContext.Provider>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/app/routes/admin._index/contexts/PostContext.tsx
+++ b/app/routes/admin._index/contexts/PostContext.tsx
@@ -1,0 +1,20 @@
+import type {SerializeFrom} from "@remix-run/node"
+import {createContext, useContext} from "react"
+
+import type {MaybeNull} from "../../../lib/types/MaybeNull.js"
+
+import {loader} from "../route.jsx"
+
+export type PostContextData = Omit<SerializeFrom<typeof loader>, "title">["list"][number]
+
+export const PostContext = createContext<MaybeNull<PostContextData>>(null)
+
+export function usePostContext(): PostContextData {
+  const context = useContext(PostContext)
+
+  if (!context) {
+    throw new Error("Unable to find PostContext")
+  }
+
+  return context
+}

--- a/app/routes/admin._index/contexts/PostsContext.tsx
+++ b/app/routes/admin._index/contexts/PostsContext.tsx
@@ -1,0 +1,20 @@
+import type {SerializeFrom} from "@remix-run/node"
+import {createContext, useContext} from "react"
+
+import type {MaybeNull} from "../../../lib/types/MaybeNull.js"
+
+import {loader} from "../route.jsx"
+
+export type PostsContextData = Omit<SerializeFrom<typeof loader>, "title">
+
+export const PostsContext = createContext<MaybeNull<PostsContextData>>(null)
+
+export function usePostsContext(): PostsContextData {
+  const context = useContext(PostsContext)
+
+  if (!context) {
+    throw new Error("Unable to find PostsContext")
+  }
+
+  return context
+}

--- a/app/routes/admin._index/route.tsx
+++ b/app/routes/admin._index/route.tsx
@@ -1,0 +1,26 @@
+import {useLoaderData} from "@remix-run/react"
+
+// TODO: Replace loader on this page with it's own when I add filters
+import {loader} from "../_blog._index/route.jsx"
+
+import {NoPosts} from "./components/NoPosts.js"
+import {PostsList} from "./components/PostsList.jsx"
+import {PostsContext} from "./contexts/PostsContext.jsx"
+
+export {loader}
+
+const AdminDashboardPage = () => {
+  const page = useLoaderData<typeof loader>()
+
+  if (page.count < 0) {
+    return <NoPosts />
+  }
+
+  return (
+    <PostsContext.Provider value={page}>
+      <PostsList />
+    </PostsContext.Provider>
+  )
+}
+
+export default AdminDashboardPage


### PR DESCRIPTION
### Details

This PR groups ui elements for admin dashboard home page.

### Changes

- [x] Add `admin._index` folder to co-locate dashboard's home page ui elements together;
- [x] Add posts list
- [x] Add posts and post contexts

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] ~~I have added changesets <!-- optional -->~~
- [x] ~~I have brought tests <!-- if necessary -->~~
