### PR TITLE
feat(build-server): Move server build to Vite plugin

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
 import {vitePlugin as remix} from "@remix-run/dev"
 import {defineConfig} from "vite"
-import {build} from "esbuild"
 
 import devServer from "@hono/vite-dev-server"
 import tsconfigPaths from "vite-tsconfig-paths"
+
+import buildServer from "./vite/plugins/build-server.js"
 
 export default defineConfig({
   plugins: [
@@ -12,26 +13,8 @@ export default defineConfig({
       entry: "app/server/http/dev.ts",
       exclude: [/^\/(app)\/.+/, /^\/@.+$/, /^\/node_modules\/.*/]
     }),
-    remix({
-      serverBuildFile: "remix.js",
-      async buildEnd() {
-        try {
-          build({
-            outfile: "build/server/entry.hono.js",
-            entryPoints: ["app/server/http/prod.ts"],
-            external: ["./remix.js"],
-            platform: "node",
-            format: "esm",
-            packages: "external",
-            bundle: true,
-            logLevel: "info"
-          })
-        } catch (error) {
-          console.error(error)
-          process.exit(1)
-        }
-      }
-    }),
+    remix({serverBuildFile: "remix.js"}),
+    buildServer({remixBundleName: "./remix.js"}),
     tsconfigPaths()
   ],
   optimizeDeps: {

--- a/vite/plugins/build-server.ts
+++ b/vite/plugins/build-server.ts
@@ -1,35 +1,90 @@
-import type {Plugin} from "vite"
+import {join, basename, isAbsolute} from "node:path"
+
+import type {Plugin, ResolvedConfig} from "vite"
+import {normalizePath} from "vite"
 import {build} from "esbuild"
 
 interface BuildServerPluginOptions {
   /**
-   * Remix bundle id to be excluded from server bundle dependencies
+   * Remix bundle id to be excluded from server bundle dependencies.
+   *
+   * This path would be relative to the server's output file path
    */
   remixBundleName: string
 
-  entryPoint?: string
+  /**
+   * Path to server entry point
+   */
+  entryPointFileName?: string
 
-  outputFile?: string
+  /**
+   * Path to server output file
+   */
+  outputFileName?: string
+}
+
+const defaults: Required<Omit<BuildServerPluginOptions, "remixBundleName">> = {
+  entryPointFileName: "app/server/http/prod.ts",
+  outputFileName: "entry.hono.js"
+}
+
+function normalizeEntryPointFileName(
+  fileName: string,
+  config: ResolvedConfig
+): string {
+  const path = isAbsolute(fileName)
+    ? fileName
+    : normalizePath(join(config.root, fileName))
+
+  if (!path.startsWith(config.root)) {
+    throw Error(
+      `Unable to resolve server entry poing: The path bust be within the project's root. Received: ${path}`
+    )
+  }
+
+  return path
 }
 
 export default function buildServer(options: BuildServerPluginOptions): Plugin {
+  let config: ResolvedConfig | undefined
+
   return {
     name: "vite-plugin-eri-build-server",
-    enforce: "post",
 
     // Apply this plugin only for production ssr builds
     apply: ({build}, {command}) => !!(build?.ssr && command === "build"),
 
+    configResolved(resolvedConfig) {
+      config = resolvedConfig
+    },
+
     async buildEnd() {
-      await build({
-        outfile: "build/server/entry.hono.js",
-        entryPoints: ["app/server/http/prod.ts"],
-        external: [options.remixBundleName],
+      if (!config) {
+        return this.error("Cannot run this plugin without resolved config")
+      }
+
+      const {outputFileName, remixBundleName, entryPointFileName} = {
+        ...defaults,
+        ...options
+      }
+
+      const result = await build({
+        entryPoints: [normalizeEntryPointFileName(entryPointFileName, config)],
+        external: [remixBundleName],
         platform: "node",
         format: "esm",
         packages: "external",
         bundle: true,
+        write: false,
         logLevel: "info"
+      })
+
+      const [file] = result.outputFiles
+
+      this.emitFile({
+        type: "prebuilt-chunk",
+        fileName: basename(outputFileName),
+        code: file.text
       })
     }
   }

--- a/vite/plugins/build-server.ts
+++ b/vite/plugins/build-server.ts
@@ -1,0 +1,36 @@
+import type {Plugin} from "vite"
+import {build} from "esbuild"
+
+interface BuildServerPluginOptions {
+  /**
+   * Remix bundle id to be excluded from server bundle dependencies
+   */
+  remixBundleName: string
+
+  entryPoint?: string
+
+  outputFile?: string
+}
+
+export default function buildServer(options: BuildServerPluginOptions): Plugin {
+  return {
+    name: "vite-plugin-eri-build-server",
+    enforce: "post",
+
+    // Apply this plugin only for production ssr builds
+    apply: ({build}, {command}) => !!(build?.ssr && command === "build"),
+
+    async buildEnd() {
+      await build({
+        outfile: "build/server/entry.hono.js",
+        entryPoints: ["app/server/http/prod.ts"],
+        external: [options.remixBundleName],
+        platform: "node",
+        format: "esm",
+        packages: "external",
+        bundle: true,
+        logLevel: "info"
+      })
+    }
+  }
+}


### PR DESCRIPTION
### Details

This PR introduces a Vite plugin to bundle production Hono server using esbuild.

### Changes

- [x] Add `server-build` plugin for Vite. This plugin builds Eri's production server;
- [x] Remove old server bundling code;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] ~~I have added changesets <!-- optional -->~~
- [x] ~~I have brought tests <!-- if necessary -->~~
