### PR TITLE
feat(admin/posts): Edit post

### DIFF
--- a/.changeset/angry-badgers-report.md
+++ b/.changeset/angry-badgers-report.md
@@ -1,0 +1,5 @@
+---
+"eri": patch
+---
+
+Move schema updates into postCreateCommand hook in devcontainers config

--- a/.changeset/clever-hats-shave.md
+++ b/.changeset/clever-hats-shave.md
@@ -1,0 +1,5 @@
+---
+"eri": patch
+---
+
+Fix for Slate NodeId validation

--- a/.changeset/cuddly-trainers-dream.md
+++ b/.changeset/cuddly-trainers-dream.md
@@ -1,0 +1,5 @@
+---
+"eri": patch
+---
+
+Supress hydration errors for post date on post details page and in the table at admin dashboard

--- a/.changeset/ninety-seahorses-punch.md
+++ b/.changeset/ninety-seahorses-punch.md
@@ -1,0 +1,5 @@
+---
+"eri": minor
+---
+
+Redirect to a new post address using pks

--- a/.changeset/shiny-bees-sleep.md
+++ b/.changeset/shiny-bees-sleep.md
@@ -1,0 +1,5 @@
+---
+"eri": minor
+---
+
+Add pks and update current post slug when Post.title updates

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
     }
   },
   "updateContentCommand": "sudo corepack prepare && sudo corepack enable && pnpm i --frozen-lockfile --prefer-offline",
-  "postStartCommand": "pnpm mikro-orm-esm schema:update -r",
+  "postCreateCommand": "pnpm mikro-orm-esm schema:update -r", // FIXME: I need a better way for creating schema. I think this command should run once and only when schema is out of sync with db
   "customizations": {
     "vscode": {
       "extensions": [

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -50,7 +50,7 @@ function handleBotRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  return new Promise((resolve, reject) => {
+  return new Promise<Response>((resolve, reject) => {
     let shellRendered = false
     const {pipe, abort} = renderToPipeableStream(
       <RemixServer
@@ -100,7 +100,7 @@ function handleBrowserRequest(
   responseHeaders: Headers,
   remixContext: EntryContext
 ) {
-  return new Promise((resolve, reject) => {
+  return new Promise<Response>((resolve, reject) => {
     let shellRendered = false
     const {pipe, abort} = renderToPipeableStream(
       <RemixServer

--- a/app/lib/utils/formatPostDate.ts
+++ b/app/lib/utils/formatPostDate.ts
@@ -4,4 +4,5 @@ import type {RawDate} from "../types/RawDate.js"
 
 export const POST_DATE_PATTERN = "MMMM do, y"
 
-export const formatPostDate = (date: RawDate) => format(date, POST_DATE_PATTERN)
+export const formatPostDate = (date: RawDate): string =>
+  format(date, POST_DATE_PATTERN)

--- a/app/lib/utils/toArray.ts
+++ b/app/lib/utils/toArray.ts
@@ -1,0 +1,5 @@
+/**
+ * Converts a `value` to array. If the `value` *is* array, then the copy of that array is returned
+ */
+export const toArray = <TValue>(value: TValue | TValue[]): TValue[] =>
+  Array.isArray(value) ? value.slice() : [value]

--- a/app/routes/_blog.posts.$date.$name.tsx
+++ b/app/routes/_blog.posts.$date.$name.tsx
@@ -67,7 +67,7 @@ const PostViewPage: FC = () => {
       <div className="mb-5">
         <CommonHeading variant="h1">{post.title}</CommonHeading>
 
-        <small className="text-muted-foreground">
+        <small className="text-muted-foreground" suppressHydrationWarning>
           {formatPostDate(post.createdAt)}
         </small>
       </div>

--- a/app/routes/_blog.posts.$date.$name.tsx
+++ b/app/routes/_blog.posts.$date.$name.tsx
@@ -1,5 +1,5 @@
 import {unstable_defineLoader as defineLoader} from "@remix-run/node"
-import {useLoaderData} from "@remix-run/react"
+import {useLoaderData, generatePath} from "@remix-run/react"
 import {SlateView} from "slate-to-react"
 import type {FC} from "react"
 import type {
@@ -18,6 +18,7 @@ import {Paragraph} from "../components/slate-view/elements/Paragraph.jsx"
 import {Heading} from "../components/slate-view/elements/Heading.jsx"
 import {Text} from "../components/slate-view/leaves/Text.jsx"
 
+import {checkPksLoader} from "../server/loaders/checkPksLoader.js"
 import {type IPostSlug, PostSlug} from "../server/zod/post/PostSlug.js"
 import {parseOutput} from "../server/zod/utils/parseOutput.js"
 import {formatPostDate} from "../lib/utils/formatPostDate.js"
@@ -25,9 +26,23 @@ import {parseInput} from "../server/zod/utils/parseInput.js"
 import {PostOutput} from "../server/zod/post/PostOutput.js"
 import {Post} from "../server/db/entities.js"
 
-export const loader = defineLoader(async ({params, context: {orm}}) => {
-  const slug = await parseInput(PostSlug, params as IPostSlug, {async: true})
+export const loader = defineLoader(async event => {
+  await checkPksLoader({
+    ...event,
 
+    context: {
+      ...event.context,
+
+      pksRedirect: slug => generatePath("/posts/:slug", {slug})
+    }
+  })
+
+  const {
+    params,
+    context: {orm}
+  } = event
+
+  const slug = await parseInput(PostSlug, params as IPostSlug, {async: true})
   const post = await orm.em.findOneOrFail(
     Post,
 

--- a/app/routes/admin._index/components/PostsList.tsx
+++ b/app/routes/admin._index/components/PostsList.tsx
@@ -78,7 +78,9 @@ const columns = [
     id: "createdAt",
     enableHiding: false,
     header: () => "Created",
-    cell: ctx => formatPostDate(ctx.getValue())
+    cell: ctx => (
+      <span suppressHydrationWarning>{formatPostDate(ctx.getValue())}</span>
+    )
   }),
   helper.accessor("slug", {
     id: "slug",
@@ -144,7 +146,9 @@ const columns = [
 
             <DropdownMenuSeparator />
 
-            <DropdownMenuItem>Edit</DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link to={`${createAdminPathname(post.slug)}/edit`}>Edit</Link>
+            </DropdownMenuItem>
 
             <DropdownMenuItem>Mark as draft</DropdownMenuItem>
 

--- a/app/routes/admin.posts.$date.$name._index.tsx
+++ b/app/routes/admin.posts.$date.$name._index.tsx
@@ -2,7 +2,9 @@ import type {
   MetaArgs_SingleFetch as MetaArgs,
   MetaDescriptor
 } from "@remix-run/react"
+import {generatePath} from "@remix-run/react"
 
+import {checkPksLoader} from "../server/loaders/checkPksLoader.js"
 import {type IPostSlug, PostSlug} from "../server/zod/post/PostSlug.js"
 import {defineAdminLoader} from "../server/lib/admin/defineAdminLoader.server.js"
 import {parseOutput} from "../server/zod/utils/parseOutput.js"
@@ -10,9 +12,23 @@ import {parseInput} from "../server/zod/utils/parseInput.js"
 import {PostOutput} from "../server/zod/post/PostOutput.js"
 import {Post} from "../server/db/entities.js"
 
-export const loader = defineAdminLoader(async ({params, context: {orm}}) => {
-  const slug = await parseInput(PostSlug, params as IPostSlug, {async: true})
+export const loader = defineAdminLoader(async event => {
+  await checkPksLoader({
+    ...event,
 
+    context: {
+      ...event.context,
+
+      pksRedirect: slug => generatePath("/admin/posts/:slug", {slug})
+    }
+  })
+
+  const {
+    params,
+    context: {orm}
+  } = event
+
+  const slug = await parseInput(PostSlug, params as IPostSlug, {async: true})
   const post = await orm.em.findOneOrFail(
     Post,
 

--- a/app/routes/admin.posts.$date.$name._index.tsx
+++ b/app/routes/admin.posts.$date.$name._index.tsx
@@ -1,0 +1,45 @@
+import type {
+  MetaArgs_SingleFetch as MetaArgs,
+  MetaDescriptor
+} from "@remix-run/react"
+
+import {type IPostSlug, PostSlug} from "../server/zod/post/PostSlug.js"
+import {defineAdminLoader} from "../server/lib/admin/defineAdminLoader.server.js"
+import {parseOutput} from "../server/zod/utils/parseOutput.js"
+import {parseInput} from "../server/zod/utils/parseInput.js"
+import {PostOutput} from "../server/zod/post/PostOutput.js"
+import {Post} from "../server/db/entities.js"
+
+export const loader = defineAdminLoader(async ({params, context: {orm}}) => {
+  const slug = await parseInput(PostSlug, params as IPostSlug, {async: true})
+
+  const post = await orm.em.findOneOrFail(
+    Post,
+
+    {
+      slug
+    },
+
+    {
+      filters: false, // Admin can see all posts
+      populate: ["content"],
+      failHandler(): never {
+        throw new Response(null, {
+          status: 404,
+          statusText: "Unable to find post"
+        })
+      }
+    }
+  )
+
+  return parseOutput(PostOutput, post, {async: true})
+})
+
+export const meta = ({data}: MetaArgs<typeof loader>): MetaDescriptor[] => [
+  {
+    title: data?.title
+  }
+]
+
+// Re-exporting component from public page, because they're identical. This will be changed in a future.
+export {default} from "./_blog.posts.$date.$name.jsx"

--- a/app/routes/admin.posts.$date.$name.edit.tsx
+++ b/app/routes/admin.posts.$date.$name.edit.tsx
@@ -1,0 +1,154 @@
+import type {
+  MetaArgs_SingleFetch as MetaArgs,
+  MetaDescriptor
+} from "@remix-run/react"
+import {
+  useLoaderData,
+  useActionData,
+  useNavigation,
+  json,
+  redirect,
+  generatePath
+} from "@remix-run/react"
+import {getZodConstraint, parseWithZod} from "@conform-to/zod"
+import {
+  useForm,
+  getFormProps,
+  getInputProps,
+  getTextareaProps
+} from "@conform-to/react"
+import type {FC} from "react"
+import type {z} from "zod"
+import {assign} from "@mikro-orm/mariadb"
+
+import {Breadcrumb} from "../components/common/Breadcrumbs.jsx"
+import type {BreadcrumbHandle} from "../components/common/Breadcrumbs.jsx"
+
+import {PostEditorContent} from "../components/post-editor/PostEditorContent.jsx"
+import {PostEditorTitle} from "../components/post-editor/PostEditorTitle.jsx"
+import {PostEditor} from "../components/post-editor/PostEditor.jsx"
+import {Button} from "../components/ui/Button.jsx"
+
+import {defineAdminLoader} from "../server/lib/admin/defineAdminLoader.server.js"
+import {defineAdminAction} from "../server/lib/admin/defineAdminAction.server.js"
+import {ClientPostUpdateInput} from "../server/zod/post/ClientPostUpdateInput.js"
+import {type IPostSlug, PostSlug} from "../server/zod/post/PostSlug.js"
+import {PostUpdateInput} from "../server/zod/post/PostUpdateInput.js"
+import {AdminPostOutput} from "../server/zod/admin/AdminPostOutput.js"
+import {parseOutput} from "../server/zod/utils/parseOutput.js"
+import {parseInput} from "../server/zod/utils/parseInput.js"
+import {Post} from "../server/db/entities.js"
+
+export const loader = defineAdminLoader(async ({params, context: {orm}}) => {
+  const slug = await parseInput(PostSlug, params as IPostSlug, {async: true})
+  const post = await orm.em.findOneOrFail(
+    Post,
+
+    {
+      slug
+    },
+
+    {
+      filters: false, // Admin can see all posts
+      populate: ["content"],
+      failHandler(): never {
+        throw new Response(null, {
+          status: 404,
+          statusText: "Unable to find post"
+        })
+      }
+    }
+  )
+
+  return parseOutput(AdminPostOutput, post, {async: true})
+})
+
+export const action = defineAdminAction(async ({request, context: {orm}}) => {
+  const submission = await parseWithZod(await request.formData(), {
+    schema: PostUpdateInput,
+    async: true
+  })
+
+  if (submission.status !== "success") {
+    return json(submission.reply()) // ! See https://github.com/edmundhung/conform/issues/628
+  }
+
+  const {id, ...fields} = submission.value
+
+  const post = await orm.em.findOneOrFail(
+    Post,
+
+    submission.value.id,
+
+    {
+      filters: false, // Admin can see all posts
+      populate: ["content", "pks"],
+      failHandler(): never {
+        throw new Response(null, {
+          status: 404,
+          statusText: "Unable to find post"
+        })
+      }
+    }
+  )
+
+  assign(post, fields)
+
+  await orm.em.flush()
+
+  throw redirect(generatePath("/admin/posts/:slug", {slug: post.slug}))
+})
+
+export const meta = ({data}: MetaArgs<typeof loader>): MetaDescriptor[] => [
+  {
+    title: `${data?.title} - Edit post`
+  }
+]
+
+export const handle: BreadcrumbHandle = {
+  breadcrumb: () => <Breadcrumb>Edit</Breadcrumb>
+}
+
+const AdminPostEditPage: FC = () => {
+  const navigation = useNavigation()
+  const defaultValue = useLoaderData<typeof loader>()
+  const lastResult = useActionData<typeof action>()
+
+  const [form, fields] = useForm<z.input<typeof ClientPostUpdateInput>>({
+    defaultValue,
+    lastResult: navigation.state === "idle" ? lastResult : null,
+    constraint: getZodConstraint(ClientPostUpdateInput),
+    shouldValidate: "onBlur",
+    shouldRevalidate: "onBlur",
+
+    onValidate: ({formData}) =>
+      parseWithZod(formData, {schema: ClientPostUpdateInput})
+  })
+
+  return (
+    <PostEditor
+      {...getFormProps(form)}
+      context={form.context}
+      method="patch"
+      className="contents"
+    >
+      <input
+        {...getInputProps(fields.id, {type: "hidden"})}
+        key={fields.id.key}
+      />
+
+      <PostEditorTitle
+        {...getTextareaProps(fields.title)}
+        key={fields.title.key}
+      />
+
+      <PostEditorContent meta={fields.content} key={fields.content.key} />
+
+      <div className="flex justify-end">
+        <Button type="submit">Save</Button>
+      </div>
+    </PostEditor>
+  )
+}
+
+export default AdminPostEditPage

--- a/app/routes/admin.posts.$date.$name.edit.tsx
+++ b/app/routes/admin.posts.$date.$name.edit.tsx
@@ -32,6 +32,7 @@ import {Button} from "../components/ui/Button.jsx"
 import {defineAdminLoader} from "../server/lib/admin/defineAdminLoader.server.js"
 import {defineAdminAction} from "../server/lib/admin/defineAdminAction.server.js"
 import {ClientPostUpdateInput} from "../server/zod/post/ClientPostUpdateInput.js"
+import {matchesHttpMethods} from "../server/lib/utils/matchesHttpMethods.js"
 import {type IPostSlug, PostSlug} from "../server/zod/post/PostSlug.js"
 import {PostUpdateInput} from "../server/zod/post/PostUpdateInput.js"
 import {AdminPostOutput} from "../server/zod/admin/AdminPostOutput.js"
@@ -64,6 +65,12 @@ export const loader = defineAdminLoader(async ({params, context: {orm}}) => {
 })
 
 export const action = defineAdminAction(async ({request, context: {orm}}) => {
+  if (!matchesHttpMethods(request, "PATCH")) {
+    throw new Response(null, {
+      status: 405
+    })
+  }
+
   const submission = await parseWithZod(await request.formData(), {
     schema: PostUpdateInput,
     async: true

--- a/app/routes/admin.posts.$date.$name.edit.tsx
+++ b/app/routes/admin.posts.$date.$name.edit.tsx
@@ -36,11 +36,27 @@ import {matchesHttpMethods} from "../server/lib/utils/matchesHttpMethods.js"
 import {type IPostSlug, PostSlug} from "../server/zod/post/PostSlug.js"
 import {PostUpdateInput} from "../server/zod/post/PostUpdateInput.js"
 import {AdminPostOutput} from "../server/zod/admin/AdminPostOutput.js"
+import {checkPksLoader} from "../server/loaders/checkPksLoader.js"
 import {parseOutput} from "../server/zod/utils/parseOutput.js"
 import {parseInput} from "../server/zod/utils/parseInput.js"
 import {Post} from "../server/db/entities.js"
 
-export const loader = defineAdminLoader(async ({params, context: {orm}}) => {
+export const loader = defineAdminLoader(async event => {
+  await checkPksLoader({
+    ...event,
+
+    context: {
+      ...event.context,
+
+      pksRedirect: slug => generatePath("/admin/posts/:slug/edit", {slug})
+    }
+  })
+
+  const {
+    params,
+    context: {orm}
+  } = event
+
   const slug = await parseInput(PostSlug, params as IPostSlug, {async: true})
   const post = await orm.em.findOneOrFail(
     Post,

--- a/app/routes/admin.posts.$date.$name.tsx
+++ b/app/routes/admin.posts.$date.$name.tsx
@@ -1,52 +1,13 @@
-import type {
-  MetaArgs_SingleFetch as MetaArgs,
-  MetaDescriptor
-} from "@remix-run/react"
+import {Outlet} from "@remix-run/react"
+import type {FC} from "react"
 
 import {Breadcrumb} from "../components/common/Breadcrumbs.jsx"
 import type {BreadcrumbHandle} from "../components/common/Breadcrumbs.jsx"
 
-import {type IPostSlug, PostSlug} from "../server/zod/post/PostSlug.js"
-import {defineAdminLoader} from "../server/lib/admin/defineAdminLoader.server.js"
-import {parseOutput} from "../server/zod/utils/parseOutput.js"
-import {parseInput} from "../server/zod/utils/parseInput.js"
-import {PostOutput} from "../server/zod/post/PostOutput.js"
-import {Post} from "../server/db/entities.js"
-
-export const loader = defineAdminLoader(async ({params, context: {orm}}) => {
-  const slug = await parseInput(PostSlug, params as IPostSlug, {async: true})
-
-  const post = await orm.em.findOneOrFail(
-    Post,
-
-    {
-      slug
-    },
-
-    {
-      filters: false, // Admin can see all posts
-      populate: ["content"],
-      failHandler(): never {
-        throw new Response(null, {
-          status: 404,
-          statusText: "Unable to find post"
-        })
-      }
-    }
-  )
-
-  return parseOutput(PostOutput, post, {async: true})
-})
-
-export const meta = ({data}: MetaArgs<typeof loader>): MetaDescriptor[] => [
-  {
-    title: data?.title
-  }
-]
-
 export const handle: BreadcrumbHandle = {
-  breadcrumb: () => <Breadcrumb>Post</Breadcrumb>
+  breadcrumb: ({pathname}) => <Breadcrumb href={pathname}>Post</Breadcrumb>
 }
 
-// Re-exporting component from public page, because they're identical. This will be changed in a future.
-export {default} from "./_blog.posts.$date.$name.jsx"
+const AdminPostDetailsPage: FC = () => <Outlet />
+
+export default AdminPostDetailsPage

--- a/app/server/db/entities.ts
+++ b/app/server/db/entities.ts
@@ -1,3 +1,4 @@
+export {PostPrevKnownSlug} from "./entities/PostPrevKnownSlug.js"
 export {Session} from "./entities/Session.js"
 export {User} from "./entities/User.js"
 export {Post} from "./entities/Post.js"

--- a/app/server/db/entities/Post.ts
+++ b/app/server/db/entities/Post.ts
@@ -4,14 +4,17 @@ import {
   JsonType,
   Unique,
   ManyToOne,
-  type Opt
+  OneToMany,
+  Collection
 } from "@mikro-orm/mariadb"
+import type {Opt, Hidden} from "@mikro-orm/mariadb"
 
 import {formatSlug} from "../../lib/utils/slug.js"
 
 import type {OPostContent} from "../../zod/plate/editors/PostContent.js"
 import type {OPostCreateInput} from "../../zod/post/PostCreateInput.js"
 
+import {PostPrevKnownSlug} from "./PostPrevKnownSlug.js"
 import {RecordSoft} from "./RecordSoft.js"
 import {User} from "./User.js"
 
@@ -36,14 +39,15 @@ export class Post extends RecordSoft {
   /**
    * Human-readable, unique, URL-friendly identifier of the post
    */
-  @Property<Post>({
-    type: "varchar",
-    length: 512,
-
-    onUpdate: ({title, createdAt}) => formatSlug(title, createdAt)
-  })
+  @Property<Post>({type: "varchar", length: 512})
   @Unique()
   readonly slug!: Opt<string>
+
+  /**
+   * List of previously known post `slug`
+   */
+  @OneToMany(() => PostPrevKnownSlug, "post", {hidden: true})
+  readonly pks = new Collection<Hidden<PostPrevKnownSlug>, this>(this)
 
   /**
    * The author of the post

--- a/app/server/db/entities/PostPrevKnownSlug.ts
+++ b/app/server/db/entities/PostPrevKnownSlug.ts
@@ -1,0 +1,24 @@
+import {Entity, Property, ManyToOne, Unique, type Opt} from "@mikro-orm/mariadb"
+
+import {RecordSoft} from "./RecordSoft.js"
+import {Post} from "./Post.js"
+
+@Entity()
+export class PostPrevKnownSlug extends RecordSoft {
+  @Property({type: "varchar", length: 512})
+  @Unique()
+  slug!: Opt<string>
+
+  /**
+   * The post associated with the pks
+   */
+  @ManyToOne(() => Post)
+  post: Post
+
+  constructor(post: Post) {
+    super()
+
+    this.slug = post.slug
+    this.post = post
+  }
+}

--- a/app/server/db/migrations/.snapshot-eri.json
+++ b/app/server/db/migrations/.snapshot-eri.json
@@ -418,6 +418,150 @@
         }
       },
       "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 36,
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": null,
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": null,
+          "mappedType": "datetime"
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "datetime",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": null,
+          "default": "null",
+          "mappedType": "datetime"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(512)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 512,
+          "mappedType": "string"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "varchar(36)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 36,
+          "mappedType": "string"
+        }
+      },
+      "name": "post_prev_known_slug",
+      "indexes": [
+        {
+          "columnNames": [
+            "created_at"
+          ],
+          "composite": false,
+          "keyName": "post_prev_known_slug_created_at_index",
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "updated_at"
+          ],
+          "composite": false,
+          "keyName": "post_prev_known_slug_updated_at_index",
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "removed_at"
+          ],
+          "composite": false,
+          "keyName": "post_prev_known_slug_removed_at_index",
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "slug"
+          ],
+          "composite": false,
+          "keyName": "post_prev_known_slug_slug_unique",
+          "constraint": true,
+          "primary": false,
+          "unique": true
+        },
+        {
+          "columnNames": [
+            "post_id"
+          ],
+          "composite": false,
+          "keyName": "post_prev_known_slug_post_id_index",
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "PRIMARY",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "post_prev_known_slug_post_id_foreign": {
+          "constraintName": "post_prev_known_slug_post_id_foreign",
+          "columnNames": [
+            "post_id"
+          ],
+          "localTableName": "post_prev_known_slug",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "post",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
     }
   ],
   "nativeEnums": {}

--- a/app/server/db/migrations/Migration20240908170424.ts
+++ b/app/server/db/migrations/Migration20240908170424.ts
@@ -1,0 +1,32 @@
+import {Migration} from "@mikro-orm/migrations"
+
+export class Migration20240908170424 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(
+      "create table `post_prev_known_slug` (`id` varchar(36) not null, `created_at` datetime not null, `updated_at` datetime not null, `removed_at` datetime null default null, `slug` varchar(512) not null, `post_id` varchar(36) not null, primary key (`id`)) default character set utf8mb4 engine = InnoDB;"
+    )
+    this.addSql(
+      "alter table `post_prev_known_slug` add index `post_prev_known_slug_created_at_index`(`created_at`);"
+    )
+    this.addSql(
+      "alter table `post_prev_known_slug` add index `post_prev_known_slug_updated_at_index`(`updated_at`);"
+    )
+    this.addSql(
+      "alter table `post_prev_known_slug` add index `post_prev_known_slug_removed_at_index`(`removed_at`);"
+    )
+    this.addSql(
+      "alter table `post_prev_known_slug` add unique `post_prev_known_slug_slug_unique`(`slug`);"
+    )
+    this.addSql(
+      "alter table `post_prev_known_slug` add index `post_prev_known_slug_post_id_index`(`post_id`);"
+    )
+
+    this.addSql(
+      "alter table `post_prev_known_slug` add constraint `post_prev_known_slug_post_id_foreign` foreign key (`post_id`) references `post` (`id`) on update cascade;"
+    )
+  }
+
+  override async down(): Promise<void> {
+    this.addSql("drop table if exists `post_prev_known_slug`;")
+  }
+}

--- a/app/server/db/subscribers.ts
+++ b/app/server/db/subscribers.ts
@@ -1,1 +1,2 @@
 export {UserSubscriber} from "./subscribers/UserSubscriber.js"
+export {PostSubscriber} from "./subscribers/PostSubscriber.js"

--- a/app/server/db/subscribers/PostSubscriber.ts
+++ b/app/server/db/subscribers/PostSubscriber.ts
@@ -1,0 +1,26 @@
+import type {EntityName, EventArgs, EventSubscriber} from "@mikro-orm/mariadb"
+import {assign} from "@mikro-orm/mariadb"
+
+import {Post, PostPrevKnownSlug} from "../entities.js"
+import {formatSlug} from "../../lib/utils/slug.js"
+
+export class PostSubscriber implements EventSubscriber<Post> {
+  getSubscribedEntities(): EntityName<Post>[] {
+    return [Post]
+  }
+
+  async beforeUpdate(args: EventArgs<Post>): Promise<void> {
+    const {entity: post, changeSet, em} = args
+
+    if (!changeSet) {
+      return
+    }
+
+    const {payload} = changeSet
+    if (payload.title) {
+      const pks = em.create(PostPrevKnownSlug, {post})
+
+      assign(post, {slug: formatSlug(post.title, post.updatedAt), pks})
+    }
+  }
+}

--- a/app/server/lib/types/HttpMethods.ts
+++ b/app/server/lib/types/HttpMethods.ts
@@ -1,0 +1,13 @@
+/**
+ * Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+ */
+export type HttpMethods =
+  | "GET"
+  | "HEAD"
+  | "POST"
+  | "PUT"
+  | "DELETE"
+  | "CONNECT"
+  | "OPTIONS"
+  | "TRACE"
+  | "PATCH"

--- a/app/server/lib/utils/matchesHttpMethods.ts
+++ b/app/server/lib/utils/matchesHttpMethods.ts
@@ -1,0 +1,12 @@
+import type {HttpMethods} from "../types/HttpMethods.js"
+import {toArray} from "../../../lib/utils/toArray.js"
+
+export const matchesHttpMethods = <
+  TMatches extends HttpMethods | HttpMethods[]
+>(
+  request: Request,
+  matches: TMatches
+): boolean =>
+  toArray(matches).some(
+    method => request.method.toLowerCase() === method.toLowerCase()
+  )

--- a/app/server/loaders/checkPksLoader.ts
+++ b/app/server/loaders/checkPksLoader.ts
@@ -1,0 +1,41 @@
+import type {LoaderFunctionArgs, AppLoadContext} from "@remix-run/node"
+import {replace} from "@remix-run/node"
+
+import {PostSlug, type IPostSlug} from "../zod/post/PostSlug.js"
+import {parseInput} from "../zod/utils/parseInput.js"
+import {PostPrevKnownSlug} from "../db/entities.js"
+
+type CheckPksLoaderArgs = LoaderFunctionArgs & {
+  context: AppLoadContext & {
+    pksRedirect: (slug: string) => string
+  }
+}
+
+export const checkPksLoader = async ({
+  request,
+  params,
+  context: {orm, pksRedirect}
+}: CheckPksLoaderArgs) => {
+  const slug = await parseInput(PostSlug, params as unknown as IPostSlug, {
+    async: true
+  })
+
+  const pks = await orm.em.findOne(
+    PostPrevKnownSlug,
+
+    {
+      slug
+    },
+
+    {
+      fields: ["id", "post.slug"]
+    }
+  )
+
+  if (pks) {
+    const url = new URL(pksRedirect(pks.post.slug), request.url).pathname
+
+    // Redirect using Moved Permanently response status + `replace` utility for client-side navigation when possible
+    throw replace(url, 301)
+  }
+}

--- a/app/server/zod/admin/AdminPostOutput.ts
+++ b/app/server/zod/admin/AdminPostOutput.ts
@@ -1,0 +1,13 @@
+import type {z} from "zod"
+
+import {PostOutput} from "../post/PostOutput.js"
+
+export const AdminPostOutput = PostOutput.transform(post => ({
+  ...post,
+
+  content: JSON.stringify(post.content)
+}))
+
+export type IAdminPostOutput = z.input<typeof AdminPostOutput>
+
+export type OAdminPostOutput = z.output<typeof AdminPostOutput>

--- a/app/server/zod/plate/common/NodeId.ts
+++ b/app/server/zod/plate/common/NodeId.ts
@@ -1,5 +1,17 @@
 import {z} from "zod"
 
-import {NODE_ID_EXPR, NODE_ID_SIZE} from "../utils/nodeId.js"
+import {validate} from "uuid"
 
-export const NodeId = z.string().length(NODE_ID_SIZE).regex(NODE_ID_EXPR)
+import {NODE_ID_EXPR} from "../utils/nodeId.js"
+
+export const NodeId = z.string().superRefine((value, ctx) => {
+  // Support UUIDs for backward compatibility
+  if (!validate(value) && !NODE_ID_EXPR.test(value)) {
+    ctx.addIssue({
+      validation: "regex",
+      code: z.ZodIssueCode.invalid_string,
+      message:
+        "Invalid id format. Must be either UUID or 5-symbol nanoid string"
+    })
+  }
+})

--- a/app/server/zod/plate/common/WithId.ts
+++ b/app/server/zod/plate/common/WithId.ts
@@ -1,15 +1,19 @@
 import {z} from "zod"
 
+import {validate} from "uuid"
+
 import {createNodeId} from "../utils/nodeId.js"
-import {ID} from "../../common/ID.js"
 
 import {NodeId} from "./NodeId.js"
 
 export const WithId = z.object({
-  id: z.union([
-    NodeId.default(createNodeId),
-    ID.default(() => crypto.randomUUID()) // For backward compatibility
-  ])
+  id: NodeId.optional().transform(id => {
+    if (!id || validate(id)) {
+      return createNodeId()
+    }
+
+    return id
+  })
 })
 
 export type IWithId = z.input<typeof WithId>

--- a/app/server/zod/plate/utils/nodeId.ts
+++ b/app/server/zod/plate/utils/nodeId.ts
@@ -2,7 +2,7 @@ import {nanoid} from "nanoid"
 
 export const NODE_ID_SIZE = 5
 
-export const NODE_ID_EXPR = new RegExp(`^[a-zA-Z-_]{${NODE_ID_SIZE}}$`)
+export const NODE_ID_EXPR = new RegExp(`^[a-zA-Z0-9-_]{${NODE_ID_SIZE}}$`)
 
 export const createNodeId = () => nanoid(NODE_ID_SIZE)
 

--- a/app/server/zod/post/ClientPostUpdateInput.ts
+++ b/app/server/zod/post/ClientPostUpdateInput.ts
@@ -1,0 +1,11 @@
+import {z} from "zod"
+
+import {PostUpdateInput} from "./PostUpdateInput.js"
+
+export const ClientPostUpdateInput = PostUpdateInput.extend({
+  content: z.string().min(1)
+})
+
+export type IClientPostUpdateInput = z.input<typeof ClientPostUpdateInput>
+
+export type OClientPostUpdateInput = z.output<typeof ClientPostUpdateInput>

--- a/app/server/zod/post/PostUpdateInput.ts
+++ b/app/server/zod/post/PostUpdateInput.ts
@@ -1,0 +1,10 @@
+import type {z} from "zod"
+
+import {PostCreateInput} from "./PostCreateInput.js"
+import {Node} from "../common/Node.js"
+
+export const PostUpdateInput = Node.extend(PostCreateInput.partial().shape)
+
+export type IPostUpdateInput = z.input<typeof PostUpdateInput>
+
+export type OPostUpdateInput = z.output<typeof PostUpdateInput>


### PR DESCRIPTION
### Details

Support post updates and preserve previously known post slug so we can redirect to the new address.

Resolves #77

### Changes

- [x] Add `PostPrevKnownSlug` entity;
- [x] Add `PostSubscriber` to update `slug` and add new `pks` when `Post.title` is changed;
- [x] Add migration;
- [x] Add `admin.posts.$date.$name.edit` module for `/admin/posts/:date/:name/edit` route;
- [x] Add loader to request data page data;
  - [x] Every post details loader should be able to redirect to the new post address, when the post is requested via previously known post slug;
- [x] Add action to handle post updates;
  - [x] The restrict action to `PATCH` method;
- [x] Support initial data in `PostContentEditor`;
- [x] Move schema updates command to `postCreateCommand` hook (devcontainers);
- [x] Fix Slate NodeId validation;
- [x] Add link to post edit page to posts table on admin dashboard;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] I have added changesets <!-- optional -->
- [x] ~~I have brought tests <!-- if necessary -->~~
