### PR TITLE
chore(pnpm): Specify set of OS and CPUs for native dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,12 @@
       "./build/db/mikro-orm.config.js"
     ]
   },
+  "pnpm": {
+    "supportedArchitectures": {
+      "os": ["darwin", "linux"],
+      "cpu": ["x64", "arm64"]
+    }
+  },
   "dependencies": {
     "@conform-to/react": "1.1.5",
     "@conform-to/zod": "1.1.5",


### PR DESCRIPTION
### Details

This PR adds `pnpm` config to package.json with `supportedArchitectures` option, so that it will fetch native dependencies for multiple platforms during installation.

### Changes

- [x] Add `supportedArchitectures` option with following targets:
  - [x] `os`: `linux` and `darwin` (macOS);
  - [x] `cpu`: `x64` and `arm64`;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] ~~I have added changesets <!-- optional -->~~
- [x] ~~I have brought tests <!-- if necessary -->~~
