### PR TITLE
chore(remix): Update settings for remix plugin for Vite

### DIFF
--- a/.changeset/rude-balloons-rule.md
+++ b/.changeset/rude-balloons-rule.md
@@ -1,0 +1,5 @@
+---
+"eri": minor
+---
+
+Enable all Remix future flags

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -80,7 +80,7 @@ function handleBotRequest(
         },
         onError(error: unknown) {
           responseStatusCode = 500
-          // Log streaming rendering errors from inside the shell.  Don't log
+          // Log streaming rendering errors from inside the shell. Don't log
           // errors encountered during initial shell rendering since they'll
           // reject and get logged in handleDocumentRequest.
           if (shellRendered) {
@@ -126,7 +126,7 @@ function handleBrowserRequest(
         },
         onError(error: unknown) {
           responseStatusCode = 500
-          // Log streaming rendering errors from inside the shell.  Don't log
+          // Log streaming rendering errors from inside the shell. Don't log
           // errors encountered during initial shell rendering since they'll
           // reject and get logged in handleDocumentRequest.
           if (shellRendered) {

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -42,7 +42,11 @@ export const server = await createHonoServer({
     console.log("🥕 Listening on http://localhost:%s", port)
 })
 
-const ABORT_DELAY = 5_000
+export const streamTimeout = 5_000
+
+// Automatically timeout the React renderer after 6 seconds, which ensures
+// React has enough time to flush down the rejected boundary contents
+const abortDelay = streamTimeout + 1_000
 
 function handleBotRequest(
   request: Request,
@@ -53,11 +57,7 @@ function handleBotRequest(
   return new Promise<Response>((resolve, reject) => {
     let shellRendered = false
     const {pipe, abort} = renderToPipeableStream(
-      <RemixServer
-        context={remixContext}
-        url={request.url}
-        abortDelay={ABORT_DELAY}
-      />,
+      <RemixServer context={remixContext} url={request.url} />,
       {
         onAllReady() {
           shellRendered = true
@@ -90,7 +90,7 @@ function handleBotRequest(
       }
     )
 
-    setTimeout(abort, ABORT_DELAY)
+    setTimeout(abort, abortDelay)
   })
 }
 
@@ -103,11 +103,7 @@ function handleBrowserRequest(
   return new Promise<Response>((resolve, reject) => {
     let shellRendered = false
     const {pipe, abort} = renderToPipeableStream(
-      <RemixServer
-        context={remixContext}
-        url={request.url}
-        abortDelay={ABORT_DELAY}
-      />,
+      <RemixServer context={remixContext} url={request.url} />,
       {
         onShellReady() {
           shellRendered = true
@@ -140,7 +136,7 @@ function handleBrowserRequest(
       }
     )
 
-    setTimeout(abort, ABORT_DELAY)
+    setTimeout(abort, abortDelay)
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "@commitlint/types": "19.5.0",
     "@faker-js/faker": "9.0.3",
     "@remix-run/dev": "2.13.1",
-    "@remix-run/server-runtime": "2.13.1",
     "@tailwindcss/typography": "0.5.15",
     "@types/is-hotkey": "0.1.10",
     "@types/node": "22.7.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,9 +288,6 @@ importers:
       '@remix-run/dev':
         specifier: 2.13.1
         version: 2.13.1(@remix-run/react@2.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@types/node@22.7.5)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.6.3))(typescript@5.6.3)(vite@5.4.8(@types/node@22.7.5))
-      '@remix-run/server-runtime':
-        specifier: 2.13.1
-        version: 2.13.1(typescript@5.6.3)
       '@tailwindcss/typography':
         specifier: 0.5.15
         version: 0.5.15(tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.6.3)))

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,9 +7,9 @@ import tsconfigPaths from "vite-tsconfig-paths"
 
 installGlobals({nativeFetch: true})
 
-declare module "@remix-run/server-runtime" {
+declare module "@remix-run/node" {
   interface Future {
-    singleFetch: true // 👈 this enables _types_ for single-fetch
+    v3_singleFetch: true // 👈 this enables _types_ for single-fetch
   }
 }
 
@@ -22,7 +22,10 @@ export default defineConfig({
       ignoredRouteFiles: [TESTS_SEARCH_PATTERN],
       future: {
         v3_singleFetch: true,
+        v3_fetcherPersist: true,
+        v3_throwAbortReason: true,
         v3_lazyRouteDiscovery: true,
+        v3_relativeSplatPath: true,
         unstable_optimizeDeps: true
       }
     }),


### PR DESCRIPTION
### Details

This PR enables all Remix future flags to prepare the app for migration to React Router v7 when it'll released.

### Changes

- [x] Enable all Remix future flags;
- [x] Fix Future interface extension. Also update module from `@remix-run/server-runtime` to `@remix-run/node` as the docs suggest;
- [x] Remove `@remix-run/server-runtime` from devDependencties;
- [x] Update entry.server.tsx according to Single Fetch [migration guide](https://remix.run/docs/en/main/start/future-flags#v3_singlefetch);

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] I have added changesets <!-- optional -->
- [x] ~~I have brought tests <!-- if necessary -->~~
