### PR TITLE
chore(shadcn/ui): Remove forwardRef

### DIFF
--- a/.changeset/chilly-yaks-trade.md
+++ b/.changeset/chilly-yaks-trade.md
@@ -1,0 +1,5 @@
+---
+"eri": patch
+---
+
+Bump better-auth to latest stable version

--- a/.changeset/few-olives-trade.md
+++ b/.changeset/few-olives-trade.md
@@ -1,0 +1,5 @@
+---
+"eri": patch
+---
+
+Remove forwardRef from shadcn/ui components

--- a/app/components/ui/Breadcrumb.tsx
+++ b/app/components/ui/Breadcrumb.tsx
@@ -1,134 +1,116 @@
 import {Slot} from "@radix-ui/react-slot"
 import {cn} from "@udecode/cn"
 import {ChevronRight, MoreHorizontal} from "lucide-react"
-import type {ComponentPropsWithoutRef, ElementRef, ReactNode} from "react"
+import type {ComponentProps, ComponentRef, FC, ReactNode} from "react"
 import {forwardRef} from "react"
 
-export type BreadcrumbRef = ElementRef<"nav">
-
-export type BreadcrumbProps = ComponentPropsWithoutRef<"nav"> & {
+export interface BreadcrumbProps extends ComponentProps<"nav"> {
   separator?: ReactNode
 }
 
-export const Breadcrumb = forwardRef<BreadcrumbRef, BreadcrumbProps>(
-  ({...props}, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />
+export const Breadcrumb: FC<BreadcrumbProps> = ({...props}) => (
+  <nav aria-label="breadcrumb" {...props} />
 )
 
-Breadcrumb.displayName = "Breadcrumb"
+export type BreadcrumbRef = ComponentRef<typeof Breadcrumb>
 
-export type BreadcrumbListRef = ElementRef<"ol">
+export type BreadcrumbListProps = ComponentProps<"ol">
 
-export type BreadcrumbListProps = ComponentPropsWithoutRef<"ol">
-
-export const BreadcrumbList = forwardRef<
-  BreadcrumbListRef,
-  BreadcrumbListProps
->(({className, ...props}, ref) => (
+export const BreadcrumbList: FC<BreadcrumbListProps> = ({
+  className,
+  ...props
+}) => (
   <ol
     {...props}
-    ref={ref}
     className={cn(
       "flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5",
       className
     )}
   />
-))
+)
 
-BreadcrumbList.displayName = "BreadcrumbList"
+export type BreadcrumbListRef = ComponentRef<typeof BreadcrumbList>
 
-export type BreadcrumbItemRef = ElementRef<"li">
+export type BreadcrumbItemProps = ComponentProps<"li">
 
-export type BreadcrumbItemProps = ComponentPropsWithoutRef<"li">
-
-export const BreadcrumbItem = forwardRef<
-  BreadcrumbItemRef,
-  BreadcrumbItemProps
->(({className, ...props}, ref) => (
+export const BreadcrumbItem: FC<BreadcrumbItemProps> = ({
+  className,
+  ...props
+}) => (
   <li
     {...props}
-    ref={ref}
     className={cn("inline-flex items-center gap-1.5", className)}
   />
-))
+)
 
-BreadcrumbItem.displayName = "BreadcrumbItem"
+export type BreadcrumbItemRef = ComponentRef<"li">
 
-export type BreadcrumbLinkRef = ElementRef<"a">
-
-export type BreadcrumbLinkProps = ComponentPropsWithoutRef<"a"> & {
+export interface BreadcrumbLinkProps extends ComponentProps<"a"> {
   asChild?: boolean
 }
 
-export const BreadcrumbLink = forwardRef<
-  BreadcrumbLinkRef,
-  BreadcrumbLinkProps
->(({asChild, className, ...props}, ref) => {
+export const BreadcrumbLink: FC<BreadcrumbLinkProps> = ({
+  asChild,
+  className,
+  ...props
+}) => {
   const Comp = asChild ? Slot : "a"
 
   return (
     <Comp
-      ref={ref}
       className={cn("transition-colors hover:text-foreground", className)}
       {...props}
     />
   )
-})
+}
 
-BreadcrumbLink.displayName = "BreadcrumbLink"
+export type BreadcrumbLinkRef = ComponentRef<"a">
 
-export type BreadcrumbPageRef = ElementRef<"span">
+export type BreadcrumbPageProps = ComponentProps<"span">
 
-export type BreadcrumbPageProps = ComponentPropsWithoutRef<"span">
-
-export const BreadcrumbPage = forwardRef<
-  BreadcrumbPageRef,
-  BreadcrumbPageProps
->(({className, ...props}, ref) => (
+export const BreadcrumbPage: FC<BreadcrumbPageProps> = ({
+  className,
+  ...props
+}) => (
   // biome-ignore lint/a11y/useFocusableInteractive: Disabled because this code is generated
   <span
     {...props}
-    ref={ref}
     role="link"
     aria-disabled="true"
     aria-current="page"
     className={cn("font-normal text-foreground", className)}
   />
-))
+)
 
-BreadcrumbPage.displayName = "BreadcrumbPage"
+export type BreadcrumbPageRef = ComponentRef<"span">
 
-export type BreadcrumbSeparatorRef = ElementRef<"li">
+export type BreadcrumbSeparatorProps = ComponentProps<"li">
 
-export type BreadcrumbSeparatorProps = ComponentPropsWithoutRef<"li">
-
-export const BreadcrumbSeparator = forwardRef<
-  BreadcrumbSeparatorRef,
-  BreadcrumbSeparatorProps
->(({children, className, ...props}, ref) => (
+export const BreadcrumbSeparator: FC<BreadcrumbSeparatorProps> = ({
+  children,
+  className,
+  ...props
+}) => (
   <li
     {...props}
-    ref={ref}
     role="presentation"
     aria-hidden="true"
     className={cn("[&>svg]:size-3.5", className)}
   >
     {children ?? <ChevronRight />}
   </li>
-))
+)
 
-BreadcrumbSeparator.displayName = "BreadcrumbSeparator"
+export type BreadcrumbSeparatorRef = ComponentRef<"li">
 
-export type BreadcrumbEllipsisRef = ElementRef<"span">
+export type BreadcrumbEllipsisProps = ComponentProps<"span">
 
-export type BreadcrumbEllipsisProps = ComponentPropsWithoutRef<"span">
-
-export const BreadcrumbEllipsis = forwardRef<
-  BreadcrumbEllipsisRef,
-  BreadcrumbEllipsisProps
->(({className, ...props}, ref) => (
+export const BreadcrumbEllipsis: FC<BreadcrumbEllipsisProps> = ({
+  className,
+  ...props
+}) => (
   <span
     {...props}
-    ref={ref}
     role="presentation"
     aria-hidden="true"
     className={cn("flex h-9 w-9 items-center justify-center", className)}
@@ -136,6 +118,6 @@ export const BreadcrumbEllipsis = forwardRef<
     <MoreHorizontal className="h-4 w-4" />
     <span className="sr-only">More</span>
   </span>
-))
+)
 
-BreadcrumbEllipsis.displayName = "BreadcrumbElipssis"
+export type BreadcrumbEllipsisRef = ComponentRef<"span">

--- a/app/components/ui/Button.tsx
+++ b/app/components/ui/Button.tsx
@@ -1,7 +1,7 @@
 import {Slot} from "@radix-ui/react-slot"
 import {cn} from "@udecode/cn"
 import {type VariantProps, cva} from "class-variance-authority"
-import {type ComponentPropsWithoutRef, forwardRef} from "react"
+import type {ComponentProps, ComponentRef, FC} from "react"
 
 export const buttonVariants = cva(
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 gap-2 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -37,23 +37,27 @@ export const buttonVariants = cva(
 )
 
 export interface ButtonProps
-  extends ComponentPropsWithoutRef<"button">,
+  extends ComponentProps<"button">,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean
 }
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({className, variant, wide, size, asChild = false, ...props}, ref) => {
-    const Comp = asChild ? Slot : "button"
+export const Button: FC<ButtonProps> = ({
+  className,
+  variant,
+  wide,
+  size,
+  asChild = false,
+  ...props
+}) => {
+  const Comp = asChild ? Slot : "button"
 
-    return (
-      <Comp
-        {...props}
-        className={cn(buttonVariants({variant, size, wide, className}))}
-        ref={ref}
-      />
-    )
-  }
-)
+  return (
+    <Comp
+      {...props}
+      className={cn(buttonVariants({variant, size, wide, className}))}
+    />
+  )
+}
 
-Button.displayName = "Button"
+export type ButtonRef = ComponentRef<typeof Button>

--- a/app/components/ui/Card.tsx
+++ b/app/components/ui/Card.tsx
@@ -1,42 +1,37 @@
 import {cn} from "@udecode/cn"
-import type {HTMLAttributes} from "react"
-import {forwardRef} from "react"
+import type {ComponentProps, ComponentRef, FC} from "react"
 
-export const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({className, ...props}, ref) => (
-    <div
-      ref={ref}
-      className={cn(
-        "rounded-lg border bg-card text-card-foreground shadow-xs",
-        className
-      )}
-      {...props}
-    />
-  )
-)
+export type CardProps = ComponentProps<"div">
 
-Card.displayName = "Card"
-
-export const CardHeader = forwardRef<
-  HTMLDivElement,
-  HTMLAttributes<HTMLDivElement>
->(({className, ...props}, ref) => (
+export const Card: FC<CardProps> = ({className, ...props}) => (
   <div
-    ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-xs",
+      className
+    )}
     {...props}
   />
-))
+)
 
-CardHeader.displayName = "CardHeader"
+export type CardRef = ComponentRef<typeof Card>
 
-export const CardTitle = forwardRef<
-  HTMLParagraphElement,
-  HTMLAttributes<HTMLHeadingElement>
->(({className, children, ...props}, ref) => (
+export type CardHeaderProps = ComponentProps<"div">
+
+export const CardHeader: FC<CardHeaderProps> = ({className, ...props}) => (
+  <div className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+)
+
+export type CardHeaderRef = ComponentRef<typeof CardHeader>
+
+export type CardTitleProps = ComponentProps<"h3">
+
+export const CardTitle: FC<CardTitleProps> = ({
+  className,
+  children,
+  ...props
+}) => (
   <h3
     {...props}
-    ref={ref}
     className={cn(
       "text-2xl font-semibold leading-none tracking-tight",
       className
@@ -44,41 +39,33 @@ export const CardTitle = forwardRef<
   >
     {children}
   </h3>
-))
+)
 
-CardTitle.displayName = "CardTitle"
+export type CardTitleRef = ComponentRef<typeof CardTitle>
 
-export const CardDescription = forwardRef<
-  HTMLParagraphElement,
-  HTMLAttributes<HTMLParagraphElement>
->(({className, ...props}, ref) => (
-  <p
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
+export type CardDescriptionProps = ComponentProps<"p">
 
-CardDescription.displayName = "CardDescription"
+export const CardDescription: FC<CardDescriptionProps> = ({
+  className,
+  ...props
+}) => (
+  <p className={cn("text-sm text-muted-foreground", className)} {...props} />
+)
 
-export const CardContent = forwardRef<
-  HTMLDivElement,
-  HTMLAttributes<HTMLDivElement>
->(({className, ...props}, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-))
+export type CardDescriptionRef = ComponentRef<typeof CardDescription>
 
-CardContent.displayName = "CardContent"
+export type CardContentProps = ComponentProps<"div">
 
-export const CardFooter = forwardRef<
-  HTMLDivElement,
-  HTMLAttributes<HTMLDivElement>
->(({className, ...props}, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
-    {...props}
-  />
-))
+export const CardContent: FC<CardContentProps> = ({className, ...props}) => (
+  <div className={cn("p-6 pt-0", className)} {...props} />
+)
 
-CardFooter.displayName = "CardFooter"
+export type CardContentRef = ComponentRef<typeof CardContent>
+
+export type CardFooterProps = ComponentProps<"div">
+
+export const CardFooter: FC<CardFooterProps> = ({className, ...props}) => (
+  <div className={cn("flex items-center p-6 pt-0", className)} {...props} />
+)
+
+export type CardFooterRef = ComponentRef<typeof CardFooter>

--- a/app/components/ui/Checkbox.tsx
+++ b/app/components/ui/Checkbox.tsx
@@ -1,30 +1,22 @@
 import {Indicator, Root} from "@radix-ui/react-checkbox"
 import {cn} from "@udecode/cn"
 import {Check} from "lucide-react"
-import type {ComponentPropsWithoutRef, ElementRef} from "react"
-import {forwardRef} from "react"
+import type {ComponentProps, ComponentRef, FC} from "react"
 
-export type CheckboxRef = ElementRef<typeof Root>
+export type CheckboxProps = ComponentProps<typeof Root>
 
-export type CheckboxProps = ComponentPropsWithoutRef<typeof Root>
-
-export const Checkbox = forwardRef<CheckboxRef, CheckboxProps>(
-  ({className, ...props}, ref) => (
-    <Root
-      ref={ref}
-      className={cn(
-        "w-4 h-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
-        className
-      )}
-      {...props}
-    >
-      <Indicator
-        className={cn("flex items-center justify-center text-current")}
-      >
-        <Check size={14} />
-      </Indicator>
-    </Root>
-  )
+export const Checkbox: FC<CheckboxProps> = ({className, ...props}) => (
+  <Root
+    className={cn(
+      "w-4 h-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <Indicator className={cn("flex items-center justify-center text-current")}>
+      <Check size={14} />
+    </Indicator>
+  </Root>
 )
 
-Checkbox.displayName = Root.displayName
+export type CheckboxRef = ComponentRef<typeof Checkbox>

--- a/app/components/ui/DropdownMenu.tsx
+++ b/app/components/ui/DropdownMenu.tsx
@@ -17,8 +17,7 @@ import {
 } from "@radix-ui/react-dropdown-menu"
 import {cn} from "@udecode/cn"
 import {Check, ChevronRight, Circle} from "lucide-react"
-import type {ComponentPropsWithoutRef, ElementRef, FC} from "react"
-import {forwardRef} from "react"
+import type {ComponentProps, ComponentRef, FC} from "react"
 
 interface WithInset {
   inset?: boolean
@@ -36,18 +35,17 @@ export const DropdownMenuSub = Sub
 
 export const DropdownMenuRadioGroup = RadioGroup
 
-export type DropdownMenuSubTriggerRef = ElementRef<typeof SubTrigger>
-
 export interface DropdownMenuSubTriggerProps
-  extends ComponentPropsWithoutRef<typeof SubTrigger>,
+  extends ComponentProps<typeof SubTrigger>,
     WithInset {}
 
-export const DropdownMenuSubTrigger = forwardRef<
-  DropdownMenuSubTriggerRef,
-  DropdownMenuSubTriggerProps
->(({className, inset, children, ...props}, ref) => (
+export const DropdownMenuSubTrigger: FC<DropdownMenuSubTriggerProps> = ({
+  className,
+  inset,
+  children,
+  ...props
+}) => (
   <SubTrigger
-    ref={ref}
     className={cn(
       "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent data-[state=open]:bg-accent",
 
@@ -62,42 +60,42 @@ export const DropdownMenuSubTrigger = forwardRef<
     {children}
     <ChevronRight className="ml-auto h-4 w-4" />
   </SubTrigger>
-))
+)
 
-DropdownMenuSubTrigger.displayName = SubTrigger.displayName
-
-export type DropdownMenuSubContentRef = ElementRef<typeof SubContent>
+export type DropdownMenuSubTriggerRef = ComponentRef<
+  typeof DropdownMenuSubTrigger
+>
 
 export interface DropdownMenuSubContentProps
-  extends ComponentPropsWithoutRef<typeof SubContent> {}
+  extends ComponentProps<typeof SubContent> {}
 
-export const DropdownMenuSubContent = forwardRef<
-  DropdownMenuSubContentRef,
-  DropdownMenuSubContentProps
->(({className, ...props}, ref) => (
+export const DropdownMenuSubContent: FC<DropdownMenuSubContentProps> = ({
+  className,
+  ...props
+}) => (
   <SubContent
-    ref={ref}
     className={cn(
       "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
   />
-))
-DropdownMenuSubContent.displayName = SubContent.displayName
+)
 
-export type DropdownMenuContentRef = ElementRef<typeof Content>
+export type DropdownMenuSubContentRef = ComponentRef<
+  typeof DropdownMenuSubContent
+>
 
 export interface DropdownMenuContentProps
-  extends ComponentPropsWithoutRef<typeof Content> {}
+  extends ComponentProps<typeof Content> {}
 
-export const DropdownMenuContent = forwardRef<
-  DropdownMenuContentRef,
-  DropdownMenuContentProps
->(({className, sideOffset = 4, ...props}, ref) => (
+export const DropdownMenuContent: FC<DropdownMenuContentProps> = ({
+  className,
+  sideOffset = 4,
+  ...props
+}) => (
   <Portal>
     <Content
-      ref={ref}
       sideOffset={sideOffset}
       className={cn(
         "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
@@ -106,22 +104,20 @@ export const DropdownMenuContent = forwardRef<
       {...props}
     />
   </Portal>
-))
+)
 
-DropdownMenuContent.displayName = Content.displayName
-
-export type DropdownMenuItemRef = ElementRef<typeof Item>
+export type DropdownMenuContentRef = ComponentRef<typeof DropdownMenuContent>
 
 export interface DropdownMenuItemProps
-  extends ComponentPropsWithoutRef<typeof Item>,
+  extends ComponentProps<typeof Item>,
     WithInset {}
 
-export const DropdownMenuItem = forwardRef<
-  DropdownMenuItemRef,
-  DropdownMenuItemProps
->(({className, inset, ...props}, ref) => (
+export const DropdownMenuItem: FC<DropdownMenuItemProps> = ({
+  className,
+  inset,
+  ...props
+}) => (
   <Item
-    ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
 
@@ -133,21 +129,20 @@ export const DropdownMenuItem = forwardRef<
     )}
     {...props}
   />
-))
+)
 
-DropdownMenuItem.displayName = Item.displayName
-
-export type DropdownMenuCheckboxItemRef = ElementRef<typeof CheckboxItem>
+export type DropdownMenuItemRef = ComponentRef<typeof DropdownMenuItem>
 
 export interface DropdownMenuCheckboxItemProps
-  extends ComponentPropsWithoutRef<typeof CheckboxItem> {}
+  extends ComponentProps<typeof CheckboxItem> {}
 
-export const DropdownMenuCheckboxItem = forwardRef<
-  DropdownMenuCheckboxItemRef,
-  DropdownMenuCheckboxItemProps
->(({className, children, checked, ...props}, ref) => (
+export const DropdownMenuCheckboxItem: FC<DropdownMenuCheckboxItemProps> = ({
+  className,
+  children,
+  checked,
+  ...props
+}) => (
   <CheckboxItem
-    ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
       className
@@ -160,23 +155,24 @@ export const DropdownMenuCheckboxItem = forwardRef<
         <Check className="h-4 w-4" />
       </ItemIndicator>
     </span>
+
     {children}
   </CheckboxItem>
-))
+)
 
-DropdownMenuCheckboxItem.displayName = CheckboxItem.displayName
-
-export type DropdownMenuRadioItemRef = ElementRef<typeof RadioItem>
+export type DropdownMenuCheckboxItemRef = ComponentRef<
+  typeof DropdownMenuCheckboxItem
+>
 
 export interface DropdownMenuRadioItemProps
-  extends ComponentPropsWithoutRef<typeof RadioItem> {}
+  extends ComponentProps<typeof RadioItem> {}
 
-export const DropdownMenuRadioItem = forwardRef<
-  DropdownMenuLabelRef,
-  DropdownMenuRadioItemProps
->(({className, children, ...props}, ref) => (
+export const DropdownMenuRadioItem: FC<DropdownMenuRadioItemProps> = ({
+  className,
+  children,
+  ...props
+}) => (
   <RadioItem
-    ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
       className
@@ -188,24 +184,25 @@ export const DropdownMenuRadioItem = forwardRef<
         <Circle className="h-2 w-2 fill-current" />
       </ItemIndicator>
     </span>
+
     {children}
   </RadioItem>
-))
+)
 
-DropdownMenuRadioItem.displayName = RadioItem.displayName
-
-export type DropdownMenuLabelRef = ElementRef<typeof Label>
+export type DropdownMenuRadioItemRef = ComponentRef<
+  typeof DropdownMenuRadioItem
+>
 
 export interface DropdownMenuLabelProps
-  extends ComponentPropsWithoutRef<typeof Label>,
+  extends ComponentProps<typeof Label>,
     WithInset {}
 
-export const DropdownMenuLabel = forwardRef<
-  DropdownMenuLabelRef,
-  DropdownMenuLabelProps
->(({className, inset, ...props}, ref) => (
+export const DropdownMenuLabel: FC<DropdownMenuLabelProps> = ({
+  className,
+  inset,
+  ...props
+}) => (
   <Label
-    ref={ref}
     className={cn(
       "px-2 py-1.5 text-sm font-semibold",
 
@@ -217,29 +214,25 @@ export const DropdownMenuLabel = forwardRef<
     )}
     {...props}
   />
-))
+)
 
-DropdownMenuLabel.displayName = Label.displayName
-
-export type DropdownMenuSeparatorRef = ElementRef<typeof Separator>
+export type DropdownMenuLabelRef = ComponentRef<typeof DropdownMenuLabel>
 
 export interface DropdownMenuSeparatorProps
-  extends ComponentPropsWithoutRef<typeof Separator> {}
+  extends ComponentProps<typeof Separator> {}
 
-export const DropdownMenuSeparator = forwardRef<
-  DropdownMenuSeparatorRef,
-  DropdownMenuSeparatorProps
->(({className, ...props}, ref) => (
-  <Separator
-    ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
-    {...props}
-  />
-))
+export const DropdownMenuSeparator: FC<DropdownMenuSeparatorProps> = ({
+  className,
+  ...props
+}) => (
+  <Separator className={cn("-mx-1 my-1 h-px bg-muted", className)} {...props} />
+)
 
-DropdownMenuSeparator.displayName = Separator.displayName
+export type DropdownMenuSeparatorRef = ComponentRef<
+  typeof DropdownMenuSeparator
+>
 
-export type DropdownMenuShortcutProps = ComponentPropsWithoutRef<"span">
+export type DropdownMenuShortcutProps = ComponentProps<"span">
 
 export const DropdownMenuShortcut: FC<DropdownMenuShortcutProps> = ({
   className,
@@ -253,4 +246,4 @@ export const DropdownMenuShortcut: FC<DropdownMenuShortcutProps> = ({
   )
 }
 
-DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
+export type DropdownMenuShortcutRef = ComponentRef<typeof DropdownMenuShortcut>

--- a/app/components/ui/Input.tsx
+++ b/app/components/ui/Input.tsx
@@ -1,27 +1,22 @@
 import {cn} from "@udecode/cn"
-import {type InputHTMLAttributes, forwardRef} from "react"
+import type {ComponentProps, FC} from "react"
 
-export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps extends ComponentProps<"input"> {
   errors?: string[]
 }
 
-export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({className, type, errors, ...props}, ref) => (
-    <input
-      {...props}
-      ref={ref}
-      type={type}
-      className={cn(
-        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+export const Input: FC<InputProps> = ({className, type, errors, ...props}) => (
+  <input
+    {...props}
+    type={type}
+    className={cn(
+      "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
 
-        {
-          "border-destructive": errors
-        },
+      {
+        "border-destructive": errors
+      },
 
-        className
-      )}
-    />
-  )
+      className
+    )}
+  />
 )
-
-Input.displayName = "Input"

--- a/app/components/ui/Label.tsx
+++ b/app/components/ui/Label.tsx
@@ -1,22 +1,18 @@
 import {Root} from "@radix-ui/react-label"
 import {cn} from "@udecode/cn"
 import {type VariantProps, cva} from "class-variance-authority"
-import type {ComponentPropsWithoutRef, ElementRef} from "react"
-import {forwardRef} from "react"
+import type {ComponentProps, ComponentRef, FC} from "react"
 
 const labelVariants = cva(
   "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 )
 
-export type LabelRef = ElementRef<typeof Root>
+export interface LabelProps
+  extends ComponentProps<typeof Root>,
+    VariantProps<typeof labelVariants> {}
 
-export type LabelProps = ComponentPropsWithoutRef<typeof Root> &
-  VariantProps<typeof labelVariants>
-
-export const Label = forwardRef<LabelRef, LabelProps>(
-  ({className, ...props}, ref) => (
-    <Root {...props} ref={ref} className={cn(labelVariants(), className)} />
-  )
+export const Label: FC<LabelProps> = ({className, ref, ...props}) => (
+  <Root {...props} ref={ref} className={cn(labelVariants(), className)} />
 )
 
-Label.displayName = Root.displayName
+export type LabelRef = ComponentRef<typeof Label>

--- a/app/components/ui/ScrollArea.tsx
+++ b/app/components/ui/ScrollArea.tsx
@@ -5,34 +5,34 @@ import {
   ScrollAreaThumb,
   Viewport
 } from "@radix-ui/react-scroll-area"
-import type {ComponentPropsWithoutRef, ElementRef} from "react"
-import {forwardRef} from "react"
+import type {ComponentProps, ComponentRef, FC} from "react"
 
 import {cn} from "@udecode/cn"
 
-export const ScrollArea = forwardRef<
-  ElementRef<typeof Root>,
-  ComponentPropsWithoutRef<typeof Root>
->(({className, children, ...props}, ref) => (
-  <Root
-    ref={ref}
-    className={cn("relative overflow-hidden", className)}
-    {...props}
-  >
+export type ScrollAreaProps = ComponentProps<typeof Root>
+
+export const ScrollArea: FC<ScrollAreaProps> = ({
+  className,
+  children,
+  ...props
+}) => (
+  <Root className={cn("relative overflow-hidden", className)} {...props}>
     <Viewport className="h-full w-full rounded-[inherit]">{children}</Viewport>
     <ScrollBar />
     <Corner />
   </Root>
-))
+)
 
-ScrollArea.displayName = Root.displayName
+export type ScrollAreaRef = ComponentRef<typeof Root>
 
-export const ScrollBar = forwardRef<
-  ElementRef<typeof ScrollAreaScrollbar>,
-  ComponentPropsWithoutRef<typeof ScrollAreaScrollbar>
->(({className, orientation = "vertical", ...props}, ref) => (
+export type ScrollBarProps = ComponentProps<typeof ScrollAreaScrollbar>
+
+export const ScrollBar: FC<ScrollBarProps> = ({
+  className,
+  orientation = "vertical",
+  ...props
+}) => (
   <ScrollAreaScrollbar
-    ref={ref}
     orientation={orientation}
     className={cn(
       "flex touch-none select-none transition-colors",
@@ -46,6 +46,6 @@ export const ScrollBar = forwardRef<
   >
     <ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
   </ScrollAreaScrollbar>
-))
+)
 
-ScrollBar.displayName = ScrollAreaScrollbar.displayName
+export type ScrollBarRef = ComponentRef<typeof ScrollAreaScrollbar>

--- a/app/components/ui/Separator.tsx
+++ b/app/components/ui/Separator.tsx
@@ -1,5 +1,5 @@
 import {Root} from "@radix-ui/react-separator"
-import type {ComponentProps, FC} from "react"
+import type {ComponentProps, ComponentRef, FC} from "react"
 
 import {cn} from "@udecode/cn"
 
@@ -9,11 +9,9 @@ export const Separator: FC<SeparatorProps> = ({
   className,
   orientation = "horizontal",
   decorative = true,
-  ref,
   ...props
 }) => (
   <Root
-    ref={ref}
     decorative={decorative}
     orientation={orientation}
     className={cn(
@@ -25,4 +23,4 @@ export const Separator: FC<SeparatorProps> = ({
   />
 )
 
-Separator.displayName = Root.displayName
+export type SeparatorRef = ComponentRef<typeof Separator>

--- a/app/components/ui/Sheet.tsx
+++ b/app/components/ui/Sheet.tsx
@@ -11,8 +11,7 @@ import {
 import {cn} from "@udecode/cn"
 import {type VariantProps, cva} from "class-variance-authority"
 import {X} from "lucide-react"
-import type {ComponentPropsWithoutRef, ElementRef} from "react"
-import {forwardRef} from "react"
+import type {ComponentProps, ComponentRef, FC} from "react"
 
 export const Sheet = Root
 
@@ -22,24 +21,19 @@ export const SheetClose = Close
 
 export const SheetPortal = Portal
 
-export type SheetOverlayRef = ElementRef<typeof Overlay>
+export type SheetOverlayRef = ComponentRef<typeof Overlay>
 
-export type SheetOverlayProps = ComponentPropsWithoutRef<typeof Overlay>
+export type SheetOverlayProps = ComponentProps<typeof Overlay>
 
-export const SheetOverlay = forwardRef<SheetOverlayRef, SheetOverlayProps>(
-  ({className, ...props}, ref) => (
-    <Overlay
-      className={cn(
-        "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-        className
-      )}
-      {...props}
-      ref={ref}
-    />
-  )
+export const SheetOverlay: FC<SheetOverlayProps> = ({className, ...props}) => (
+  <Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
 )
-
-SheetOverlay.displayName = Overlay.displayName
 
 const sheetVariants = cva(
   "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
@@ -60,101 +54,80 @@ const sheetVariants = cva(
   }
 )
 
-export type SheetContentRef = ElementRef<typeof Content>
-
 export interface SheetContentProps
-  extends ComponentPropsWithoutRef<typeof Content>,
+  extends ComponentProps<typeof Content>,
     VariantProps<typeof sheetVariants> {}
 
 // TODO: Support <Slot /> in this component
-export const SheetContent = forwardRef<SheetContentRef, SheetContentProps>(
-  ({side = "left", className, children, ...props}, ref) => (
-    <SheetPortal>
-      <SheetOverlay />
-      <Content
-        {...props}
-        ref={ref}
-        className={cn(sheetVariants({side}), className)}
-      >
-        {children}
-        <Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </Close>
-      </Content>
-    </SheetPortal>
-  )
+export const SheetContent: FC<SheetContentProps> = ({
+  side = "left",
+  className,
+  children,
+  ...props
+}) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <Content {...props} className={cn(sheetVariants({side}), className)}>
+      {children}
+      <Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </Close>
+    </Content>
+  </SheetPortal>
 )
 
-SheetContent.displayName = Content.displayName
+export type SheetContentRef = ComponentRef<typeof SheetContent>
 
-export type SheetHeaderRef = ElementRef<"div">
+export type SheetHeaderProps = ComponentProps<"div">
 
-export type SheetHeaderProps = ComponentPropsWithoutRef<"div">
-
-export const SheetHeader = forwardRef<SheetHeaderRef, SheetContentProps>(
-  ({className, ...props}, ref) => (
-    <div
-      {...props}
-      ref={ref}
-      className={cn(
-        "flex flex-col space-y-2 text-center sm:text-left",
-        className
-      )}
-    />
-  )
+export const SheetHeader: FC<SheetHeaderProps> = ({className, ...props}) => (
+  <div
+    {...props}
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+  />
 )
 
-SheetHeader.displayName = "SheetHeader"
+export type SheetHeaderRef = ComponentRef<typeof SheetHeader>
 
-export type SheetFooterRef = ElementRef<"div">
+export type SheetFooterProps = ComponentProps<"div">
 
-export type SheetFooterProps = ComponentPropsWithoutRef<"div">
-
-export const SheetFooter = forwardRef<SheetContentRef, SheetContentProps>(
-  ({className, ...props}, ref) => (
-    <div
-      {...props}
-      ref={ref}
-      className={cn(
-        "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-        className
-      )}
-    />
-  )
+export const SheetFooter: FC<SheetFooterProps> = ({className, ...props}) => (
+  <div
+    {...props}
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+  />
 )
 
-SheetFooter.displayName = "SheetFooter"
+export type SheetFooterRef = ComponentRef<typeof SheetFooter>
 
-export type SheetTitleRef = ElementRef<typeof Title>
+export type SheetTitleProps = ComponentProps<typeof Title>
 
-export type SheetTitleProps = ComponentPropsWithoutRef<typeof Title>
-
-export const SheetTitle = forwardRef<SheetTitleRef, SheetTitleProps>(
-  ({className, ...props}, ref) => (
-    <Title
-      {...props}
-      ref={ref}
-      className={cn("text-lg font-semibold text-foreground", className)}
-    />
-  )
+export const SheetTitle: FC<SheetTitleProps> = ({className, ...props}) => (
+  <Title
+    {...props}
+    className={cn("text-lg font-semibold text-foreground", className)}
+  />
 )
 
-SheetTitle.displayName = Title.displayName
+export type SheetTitleRef = ComponentRef<typeof SheetTitle>
 
-export type SheetDescriptionRef = ElementRef<typeof Description>
+export type SheetDescriptionProps = ComponentProps<typeof Description>
 
-export type SheetDescriptionProps = ComponentPropsWithoutRef<typeof Description>
-
-export const SheetDescription = forwardRef<
-  SheetDescriptionRef,
-  SheetDescriptionProps
->(({className, ...props}, ref) => (
+export const SheetDescription: FC<SheetDescriptionProps> = ({
+  className,
+  ...props
+}) => (
   <Description
     {...props}
-    ref={ref}
     className={cn("text-sm text-muted-foreground", className)}
   />
-))
+)
 
-SheetDescription.displayName = Description.displayName
+export type SheetDescriptionRef = ComponentRef<typeof SheetDescription>

--- a/app/components/ui/Table.tsx
+++ b/app/components/ui/Table.tsx
@@ -1,147 +1,112 @@
-import type {
-  ComponentPropsWithoutRef,
-  ElementRef,
-  HtmlHTMLAttributes
-} from "react"
-import {forwardRef} from "react"
+import type {ComponentProps, ComponentRef, FC} from "react"
 
 import {cn} from "@udecode/cn"
 
-export type TableRef = ElementRef<"table">
+export interface TableProps extends ComponentProps<"table"> {}
 
-export interface TableProps extends ComponentPropsWithoutRef<"table"> {}
-
-export const Table = forwardRef<TableRef, TableProps>(
-  ({className, ...props}, ref) => (
-    <div className="relative w-full overflow-auto">
-      <table
-        ref={ref}
-        className={cn("w-full caption-bottom text-sm", className)}
-        {...props}
-      />
-    </div>
-  )
-)
-
-Table.displayName = "Table"
-
-export type TableHeaderRef = ElementRef<"thead">
-
-export interface TableHeaderProps extends ComponentPropsWithoutRef<"thead"> {}
-
-export const TableHeader = forwardRef<TableHeaderRef, TableHeaderProps>(
-  ({className, ...props}, ref) => (
-    <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
-  )
-)
-
-TableHeader.displayName = "TableHeader"
-
-export type TableBodyRef = ElementRef<"tbody">
-
-export interface TableBodyProps extends ComponentPropsWithoutRef<"tbody"> {}
-
-export const TableBody = forwardRef<TableBodyRef, TableBodyProps>(
-  ({className, ...props}, ref) => (
-    <tbody
+export const Table: FC<TableProps> = ({className, ref, ...props}) => (
+  <div className="relative w-full overflow-auto">
+    <table
       ref={ref}
-      className={cn("[&_tr:last-child]:border-0", className)}
+      className={cn("w-full caption-bottom text-sm", className)}
       {...props}
     />
-  )
+  </div>
 )
 
-TableBody.displayName = "TableBody"
+export type TableRef = ComponentRef<typeof Table>
 
-export type TableFooterRef = ElementRef<"tfoot">
+export interface TableHeaderProps extends ComponentProps<"thead"> {}
 
-export interface TableFooterProps extends ComponentPropsWithoutRef<"tfoot"> {}
-
-export const TableFooter = forwardRef<TableFooterRef, TableHeaderProps>(
-  ({className, ...props}, ref) => (
-    <tfoot
-      ref={ref}
-      className={cn(
-        "border-t bg-muted/50 font-medium last:[&>tr]:border-b-0",
-        className
-      )}
-      {...props}
-    />
-  )
+export const TableHeader: FC<TableHeaderProps> = ({
+  className,
+  ref,
+  ...props
+}) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
 )
 
-TableFooter.displayName = "TableFooter"
+export type TableHeaderRef = ComponentRef<"thead">
 
-export type TableRowRef = ElementRef<"tr">
+export interface TableBodyProps extends ComponentProps<"tbody"> {}
 
-export interface TableRowProps extends ComponentPropsWithoutRef<"tr"> {}
-
-export const TableRow = forwardRef<TableRowRef, TableRowProps>(
-  ({className, ...props}, ref) => (
-    <tr
-      ref={ref}
-      className={cn(
-        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
-        className
-      )}
-      {...props}
-    />
-  )
+export const TableBody: FC<TableBodyProps> = ({className, ref, ...props}) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
 )
 
-TableRow.displayName = "TableRow"
+export type TableBodyRef = ComponentRef<typeof TableBody>
 
-export type TableHeadRef = ElementRef<"th">
+export interface TableFooterProps extends ComponentProps<"tfoot"> {}
 
-export interface TableHeadProps extends ComponentPropsWithoutRef<"th"> {}
-
-export const TableHead = forwardRef<TableHeadRef, TableHeadProps>(
-  ({className, ...props}, ref) => (
-    <th
-      ref={ref}
-      className={cn(
-        "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
-        className
-      )}
-      {...props}
-    />
-  )
+export const TableFooter: FC<TableFooterProps> = ({
+  className,
+  ref,
+  ...props
+}) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium last:[&>tr]:border-b-0",
+      className
+    )}
+    {...props}
+  />
 )
 
-TableHead.displayName = "TableHead"
+export type TableFooterRef = ComponentRef<"tfoot">
 
-export type TableCellRef = ElementRef<"td">
+export interface TableRowProps extends ComponentProps<"tr"> {}
 
-export interface TableCellProps extends ComponentPropsWithoutRef<"td"> {}
-
-export const TableCell = forwardRef<TableCellRef, TableCellProps>(
-  ({className, ...props}, ref) => (
-    <td
-      ref={ref}
-      className={cn(
-        "p-4 align-middle [&:has([role=checkbox])]:pr-0",
-        className
-      )}
-      {...props}
-    />
-  )
+export const TableRow: FC<TableRowProps> = ({className, ref, ...props}) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
 )
 
-TableCell.displayName = "TableCell"
+export type TableRowRef = ComponentRef<"tr">
 
-export type TableCaptionRef = HTMLTableCaptionElement
+export interface TableHeadProps extends ComponentProps<"th"> {}
 
-export interface TableCaptionProps
-  extends HtmlHTMLAttributes<TableCaptionRef> {}
-
-export const TableCaption = forwardRef<TableCaptionRef, TableCaptionProps>(
-  ({className, ...props}, ref) => (
-    <caption
-      ref={ref}
-      className={cn("mt-4 text-sm text-muted-foreground", className)}
-      {...props}
-    />
-  )
+export const TableHead: FC<TableHeadProps> = ({className, ref, ...props}) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
 )
 
-TableCaption.displayName = "TableCaption"
+export type TableHeadRef = ComponentRef<"th">
+
+export interface TableCellProps extends ComponentProps<"td"> {}
+
+export const TableCell: FC<TableCellProps> = ({className, ...props}) => (
+  <td
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+)
+
+export type TableCellRef = ComponentRef<"td">
+
+export interface TableCaptionProps extends ComponentProps<"caption"> {}
+
+export const TableCaption: FC<TableCaptionProps> = ({className, ...props}) => (
+  <caption
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+)
+
+export type TableCaptionRef = ComponentRef<typeof TableCaption>

--- a/app/components/ui/Textarea.tsx
+++ b/app/components/ui/Textarea.tsx
@@ -1,25 +1,19 @@
 import {cn} from "@udecode/cn"
-import type {ComponentPropsWithoutRef, ElementRef} from "react"
-import {forwardRef} from "react"
+import type {ComponentProps, ComponentRef, FC} from "react"
 
 import AutosizableTextarea from "react-textarea-autosize"
 
-export type TextareaRef = ElementRef<typeof AutosizableTextarea>
+export type TextareaProps = ComponentProps<typeof AutosizableTextarea>
 
-export type TextareaProps = ComponentPropsWithoutRef<typeof AutosizableTextarea>
+export const Textarea: FC<TextareaProps> = ({className, ...props}) => (
+  <AutosizableTextarea
+    {...props}
+    className={cn(
+      "flex min-h-[40px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
 
-export const Textarea = forwardRef<TextareaRef, TextareaProps>(
-  ({className, ...props}, ref) => (
-    <AutosizableTextarea
-      {...props}
-      ref={ref}
-      className={cn(
-        "flex min-h-[40px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
-
-        className
-      )}
-    />
-  )
+      className
+    )}
+  />
 )
 
-Textarea.displayName = "Textarea"
+export type TextareaRef = ComponentRef<typeof Textarea>

--- a/app/components/ui/Toaster.tsx
+++ b/app/components/ui/Toaster.tsx
@@ -1,7 +1,7 @@
-import type {ComponentPropsWithoutRef, FC} from "react"
+import type {ComponentProps, ComponentRef, FC} from "react"
 import {Toaster as Sonner} from "sonner"
 
-export interface ToasterProps extends ComponentPropsWithoutRef<typeof Sonner> {}
+export interface ToasterProps extends ComponentProps<typeof Sonner> {}
 
 // ! I have no idea, but without `!important` sonner theme breaks. I'll kepp it there untill I figure out what's going on here.
 export const Toaster: FC<ToasterProps> = props => (
@@ -21,3 +21,5 @@ export const Toaster: FC<ToasterProps> = props => (
     {...props}
   />
 )
+
+export type ToasterRef = ComponentRef<typeof Toaster>

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@udecode/plate-select": "38.0.1",
     "@udecode/plate-selection": "38.0.11",
     "@udecode/plate-toggle": "38.0.1",
-    "better-auth": "1.1.2-beta.3",
+    "better-auth": "1.1.3",
     "better-auth-mikro-orm": "0.1.1",
     "class-variance-authority": "0.7.1",
     "cmdk": "1.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,11 +161,11 @@ importers:
         specifier: 38.0.1
         version: 38.0.1(@udecode/plate-common@38.0.6(@types/react@19.0.2)(immer@10.1.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(scheduler@0.25.0)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.110.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate@0.103.0))(slate@0.103.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-history@0.109.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.110.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate@0.103.0))(slate@0.103.0)
       better-auth:
-        specifier: 1.1.2-beta.3
-        version: 1.1.2-beta.3
+        specifier: 1.1.3
+        version: 1.1.3
       better-auth-mikro-orm:
         specifier: 0.1.1
-        version: 0.1.1(@mikro-orm/core@6.4.1)(better-auth@1.1.2-beta.3)
+        version: 0.1.1(@mikro-orm/core@6.4.1)(better-auth@1.1.3)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -508,8 +508,8 @@ packages:
     resolution: {integrity: sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==}
     engines: {node: '>=6.9.0'}
 
-  '@better-auth/utils@0.2.1':
-    resolution: {integrity: sha512-1PgLrNJY3FZfwz8g6puKrAS/WJW3LWuNlLSFFKrzDLrn69SPBCuCXUF3tY6c1gURLX6nHARH6yx3dVy9f298cg==}
+  '@better-auth/utils@0.2.2':
+    resolution: {integrity: sha512-YlOin3pX3sc8VPRdzCOWqz6uHKitwxm/k8p6/2I1JYI0hgMWmEqqismyvEjtOKoiSTnu1huwSq+yzcN7ehu59w==}
 
   '@better-fetch/fetch@1.1.12':
     resolution: {integrity: sha512-B3bfloI/2UBQWIATRN6qmlORrvx3Mp0kkNjmXLv0b+DtbtR+pP4/I5kQA/rDUv+OReLywCCldf6co4LdDmh8JA==}
@@ -1445,20 +1445,20 @@ packages:
     resolution: {integrity: sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  '@peculiar/asn1-android@2.3.13':
-    resolution: {integrity: sha512-0VTNazDGKrLS6a3BwTDZanqq6DR/I3SbvmDMuS8Be+OYpvM6x1SRDh9AGDsHVnaCOIztOspCPc6N1m+iUv1Xxw==}
+  '@peculiar/asn1-android@2.3.15':
+    resolution: {integrity: sha512-8U2TIj59cRlSXTX2d0mzUKP7whfWGFMzTeC3qPgAbccXFrPNZLaDhpNEdG5U2QZ/tBv/IHlCJ8s+KYXpJeop6w==}
 
-  '@peculiar/asn1-ecc@2.3.14':
-    resolution: {integrity: sha512-zWPyI7QZto6rnLv6zPniTqbGaLh6zBpJyI46r1yS/bVHJXT2amdMHCRRnbV5yst2H8+ppXG6uXu/M6lKakiQ8w==}
+  '@peculiar/asn1-ecc@2.3.15':
+    resolution: {integrity: sha512-/HtR91dvgog7z/WhCVdxZJ/jitJuIu8iTqiyWVgRE9Ac5imt2sT/E4obqIVGKQw7PIy+X6i8lVBoT6wC73XUgA==}
 
-  '@peculiar/asn1-rsa@2.3.13':
-    resolution: {integrity: sha512-wBNQqCyRtmqvXkGkL4DR3WxZhHy8fDiYtOjTeCd7SFE5F6GBeafw3EJ94PX/V0OJJrjQ40SkRY2IZu3ZSyBqcg==}
+  '@peculiar/asn1-rsa@2.3.15':
+    resolution: {integrity: sha512-p6hsanvPhexRtYSOHihLvUUgrJ8y0FtOM97N5UEpC+VifFYyZa0iZ5cXjTkZoDwxJ/TTJ1IJo3HVTB2JJTpXvg==}
 
-  '@peculiar/asn1-schema@2.3.13':
-    resolution: {integrity: sha512-3Xq3a01WkHRZL8X04Zsfg//mGaA21xlL4tlVn4v2xGT0JStiztATRkMwa5b+f/HXmY2smsiLXYK46Gwgzvfg3g==}
+  '@peculiar/asn1-schema@2.3.15':
+    resolution: {integrity: sha512-QPeD8UA8axQREpgR5UTAfu2mqQmm97oUqahDtNdBcfj3qAnoXzFdQW+aNf/tD2WVXF8Fhmftxoj0eMIT++gX2w==}
 
-  '@peculiar/asn1-x509@2.3.13':
-    resolution: {integrity: sha512-PfeLQl2skXmxX2/AFFCVaWU8U6FKW1Db43mgBhShCOFS1bVxqtvusq1hVjfuEcuSQGedrLdCSvTgabluwN/M9A==}
+  '@peculiar/asn1-x509@2.3.15':
+    resolution: {integrity: sha512-0dK5xqTqSLaxv1FHXIcd4Q/BZNuopg+u1l23hT9rOmQ1g4dNtw0g/RnEi+TboB0gOwGtrWn269v27cMgchFIIg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2160,15 +2160,12 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
-  '@simplewebauthn/browser@10.0.0':
-    resolution: {integrity: sha512-hG0JMZD+LiLUbpQcAjS4d+t4gbprE/dLYop/CkE01ugU/9sKXflxV5s0DRjdz3uNMFecatRfb4ZLG3XvF8m5zg==}
+  '@simplewebauthn/browser@13.0.0':
+    resolution: {integrity: sha512-7d/+gxoFoDQxq2EkLl/PuTIQ/rnSrA3bmr8L2Ij7bRyicJoCJX/NDGUNExyctB9nSDrEkkcrJMDkwpCYOGU3Lg==}
 
-  '@simplewebauthn/server@10.0.1':
-    resolution: {integrity: sha512-djNWcRn+H+6zvihBFJSpG3fzb0NQS9c/Mw5dYOtZ9H+oDw8qn9Htqxt4cpqRvSOAfwqP7rOvE9rwqVaoGGc3hg==}
+  '@simplewebauthn/server@13.0.0':
+    resolution: {integrity: sha512-Tb3hJRpeT4cgT2uPORc465qu9LGXcDoIegFmkIgqw7XNZtsaoHzn3xI1DiFH7ukzs6JbhfQBRyY4rlfCdTwkNw==}
     engines: {node: '>=20.0.0'}
-
-  '@simplewebauthn/types@10.0.0':
-    resolution: {integrity: sha512-SFXke7xkgPRowY2E+8djKbdEznTVnD5R6GO7GPTthpHrokLvNKw8C3lFZypTxLI7KkCfGPfhtqB3d7OVGGa9jQ==}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
@@ -2863,8 +2860,8 @@ packages:
       '@mikro-orm/core': ^6.0.0
       better-auth: ^1.0.0
 
-  better-auth@1.1.2-beta.3:
-    resolution: {integrity: sha512-5a8JGy+knQUKDhRgs733NTaa0nxfOb+uGj19rBWWz7URQjbpbrWcXaU3APqi0gehutXQTqw5h8BoSJgNd0WXcQ==}
+  better-auth@1.1.3:
+    resolution: {integrity: sha512-8zUOd5zGAQLBJXupDiwAUzreLf2Msu1HVtkRWQk09hvHURZZIiuH8g48WIRXraNNoeqIA+bW70uap5Fxnj8d1w==}
 
   better-call@0.3.3-beta.4:
     resolution: {integrity: sha512-txigUTFsjOlE4dfkfhDhu6Gk0I1Xo3S4Nye+nfMKJXknb+WsymcWtqoRUSUGdhOMumM3LT9R3QttTUxwny9lWQ==}
@@ -3038,8 +3035,8 @@ packages:
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
-  cross-fetch@4.0.0:
-    resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
+  cross-fetch@4.1.0:
+    resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -3487,10 +3484,6 @@ packages:
     resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
     engines: {node: '>= 0.10'}
 
-  ipaddr.js@2.2.0:
-    resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
-    engines: {node: '>= 10'}
-
   is-absolute-url@4.0.1:
     resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3932,10 +3925,6 @@ packages:
     resolution: {integrity: sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==}
     engines: {node: ^18 || >=20}
     hasBin: true
-
-  nanostores@0.11.3:
-    resolution: {integrity: sha512-TUes3xKIX33re4QzdxwZ6tdbodjmn3tWXCEc1uokiEmo14sI1EaGYNs2k3bU2pyyGNmBqFGAVl6jAGWd06AVIg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -5332,7 +5321,7 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@better-auth/utils@0.2.1':
+  '@better-auth/utils@0.2.2':
     dependencies:
       uncrypto: 0.1.3
 
@@ -6222,37 +6211,36 @@ snapshots:
     dependencies:
       which: 3.0.1
 
-  '@peculiar/asn1-android@2.3.13':
+  '@peculiar/asn1-android@2.3.15':
     dependencies:
-      '@peculiar/asn1-schema': 2.3.13
+      '@peculiar/asn1-schema': 2.3.15
       asn1js: 3.0.5
       tslib: 2.8.1
 
-  '@peculiar/asn1-ecc@2.3.14':
+  '@peculiar/asn1-ecc@2.3.15':
     dependencies:
-      '@peculiar/asn1-schema': 2.3.13
-      '@peculiar/asn1-x509': 2.3.13
+      '@peculiar/asn1-schema': 2.3.15
+      '@peculiar/asn1-x509': 2.3.15
       asn1js: 3.0.5
       tslib: 2.8.1
 
-  '@peculiar/asn1-rsa@2.3.13':
+  '@peculiar/asn1-rsa@2.3.15':
     dependencies:
-      '@peculiar/asn1-schema': 2.3.13
-      '@peculiar/asn1-x509': 2.3.13
+      '@peculiar/asn1-schema': 2.3.15
+      '@peculiar/asn1-x509': 2.3.15
       asn1js: 3.0.5
       tslib: 2.8.1
 
-  '@peculiar/asn1-schema@2.3.13':
+  '@peculiar/asn1-schema@2.3.15':
     dependencies:
       asn1js: 3.0.5
       pvtsutils: 1.3.6
       tslib: 2.8.1
 
-  '@peculiar/asn1-x509@2.3.13':
+  '@peculiar/asn1-x509@2.3.15':
     dependencies:
-      '@peculiar/asn1-schema': 2.3.13
+      '@peculiar/asn1-schema': 2.3.15
       asn1js: 3.0.5
-      ipaddr.js: 2.2.0
       pvtsutils: 1.3.6
       tslib: 2.8.1
 
@@ -6929,25 +6917,20 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@simplewebauthn/browser@10.0.0':
-    dependencies:
-      '@simplewebauthn/types': 10.0.0
+  '@simplewebauthn/browser@13.0.0': {}
 
-  '@simplewebauthn/server@10.0.1':
+  '@simplewebauthn/server@13.0.0':
     dependencies:
       '@hexagon/base64': 1.1.28
       '@levischuck/tiny-cbor': 0.2.2
-      '@peculiar/asn1-android': 2.3.13
-      '@peculiar/asn1-ecc': 2.3.14
-      '@peculiar/asn1-rsa': 2.3.13
-      '@peculiar/asn1-schema': 2.3.13
-      '@peculiar/asn1-x509': 2.3.13
-      '@simplewebauthn/types': 10.0.0
-      cross-fetch: 4.0.0
+      '@peculiar/asn1-android': 2.3.15
+      '@peculiar/asn1-ecc': 2.3.15
+      '@peculiar/asn1-rsa': 2.3.15
+      '@peculiar/asn1-schema': 2.3.15
+      '@peculiar/asn1-x509': 2.3.15
+      cross-fetch: 4.1.0
     transitivePeerDependencies:
       - encoding
-
-  '@simplewebauthn/types@10.0.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
@@ -7673,25 +7656,24 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  better-auth-mikro-orm@0.1.1(@mikro-orm/core@6.4.1)(better-auth@1.1.2-beta.3):
+  better-auth-mikro-orm@0.1.1(@mikro-orm/core@6.4.1)(better-auth@1.1.3):
     dependencies:
       '@mikro-orm/core': 6.4.1
-      better-auth: 1.1.2-beta.3
+      better-auth: 1.1.3
       dset: 3.1.4
 
-  better-auth@1.1.2-beta.3:
+  better-auth@1.1.3:
     dependencies:
-      '@better-auth/utils': 0.2.1
+      '@better-auth/utils': 0.2.2
       '@better-fetch/fetch': 1.1.12
       '@noble/ciphers': 0.6.0
       '@noble/hashes': 1.6.1
-      '@simplewebauthn/browser': 10.0.0
-      '@simplewebauthn/server': 10.0.1
+      '@simplewebauthn/browser': 13.0.0
+      '@simplewebauthn/server': 13.0.0
       better-call: 0.3.3-beta.4
       defu: 6.1.4
       jose: 5.9.6
       kysely: 0.27.5
-      nanostores: 0.11.3
       uncrypto: 0.1.3
       zod: 3.24.1
     transitivePeerDependencies:
@@ -7881,7 +7863,7 @@ snapshots:
 
   create-require@1.1.1: {}
 
-  cross-fetch@4.0.0:
+  cross-fetch@4.1.0:
     dependencies:
       node-fetch: 2.7.0
     transitivePeerDependencies:
@@ -8344,8 +8326,6 @@ snapshots:
 
   interpret@2.2.0: {}
 
-  ipaddr.js@2.2.0: {}
-
   is-absolute-url@4.0.1: {}
 
   is-arrayish@0.2.1: {}
@@ -8681,8 +8661,6 @@ snapshots:
   nanoid@3.3.8: {}
 
   nanoid@5.0.9: {}
-
-  nanostores@0.11.3: {}
 
   node-fetch@2.7.0:
     dependencies:


### PR DESCRIPTION
### Details

This PR removes `forwardRef` usage, because React allows to pass it as regular prop since v19. See: https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop

### Changes

- [x] Remove forwardRef from shadcn/ui components;
- [x] Bump better-auth to latest stable version;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] I have added changesets <!-- optional -->
- [x] ~~I have brought tests <!-- if necessary -->~~
