### PR TITLE
feat(tooling): Publish containers ports instead of forward port

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,5 @@
 {
+  "name": "eri",
   "dockerComposeFile": "docker-compose.yaml",
   "service": "eri",
   "remoteUser": "node",
@@ -22,6 +23,5 @@
         "ms-azuretools.vscode-docker"
       ]
     }
-  },
-  "forwardPorts": [5173]
+  }
 }

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,6 +1,9 @@
 volumes:
   db_dev:
 
+networks:
+  db:
+
 services:
   eri:
     depends_on:
@@ -15,8 +18,10 @@ services:
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
 
-    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:db_dev
+    ports:
+      - 3000
+    networks:
+      - db
   
   db_dev:
     image: mariadb:lts
@@ -31,3 +36,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    ports:
+      - "3308:3306"
+    networks:
+      - db

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git+ssh://git@github.com/octet-stream/eri.git"
   },
   "scripts": {
-    "dev": "react-router dev --host",
+    "dev": "react-router dev --host --port 3000",
     "dev.open": "react-router dev --open",
     "build": "react-router build && vite -c vite.mikro-orm.config.ts build",
     "start": "NODE_ENV=production node ./build/server/index.js",


### PR DESCRIPTION
### Details

This PR changes the way how the application's and database ports exposed to local machine. Now devcontainers will publish port instead of forwarding.

See for more information: https://code.visualstudio.com/docs/devcontainers/containers#_publishing-a-port

### Changes

- [x] Update docker compose config for devcontainers;
  - [x] Add ports mapping for the `eri` (the app) and `db_dev` services:
    - [x] Database is available on `localhost:3308` port, so it won't conflict with default MariaDB and MySQL port;
    - [x] The app is available on `localhost:3000` port;
      - [x] Start dev server on the same port;
  - [x] Add `db` network and connect both services to it;
- [x] Remove `forwardPorts` option from `devcontainer.json`;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] ~~I have added changesets <!-- optional -->~~
- [x] ~~I have brought tests <!-- if necessary -->~~
