### PR TITLE
chore(deps): Bump better-auth-mikro-orm

### DIFF
--- a/.changeset/shy-donkeys-provide.md
+++ b/.changeset/shy-donkeys-provide.md
@@ -1,0 +1,5 @@
+---
+"eri": patch
+---
+
+Bump better-auth-mikro-orm

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@udecode/plate-selection": "38.0.11",
     "@udecode/plate-toggle": "38.0.1",
     "better-auth": "1.1.3",
-    "better-auth-mikro-orm": "0.1.1",
+    "better-auth-mikro-orm": "0.2.0",
     "class-variance-authority": "0.7.1",
     "cmdk": "1.0.4",
     "date-fns": "4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,8 +164,8 @@ importers:
         specifier: 1.1.3
         version: 1.1.3
       better-auth-mikro-orm:
-        specifier: 0.1.1
-        version: 0.1.1(@mikro-orm/core@6.4.1)(better-auth@1.1.3)
+        specifier: 0.2.0
+        version: 0.2.0(@mikro-orm/core@6.4.1)(better-auth@1.1.3)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -2853,8 +2853,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  better-auth-mikro-orm@0.1.1:
-    resolution: {integrity: sha512-4qlrh12x1aVrFtBKZjtoFfKdQeoWStrjFgiVuGJmhJmN51/9Ol3eW3M5/vxn/x49vU1c5akSvc1hX1GEUFKExg==}
+  better-auth-mikro-orm@0.2.0:
+    resolution: {integrity: sha512-XmZXcCP23yQmevsseGQMz/pD1QZ33VbY77kIT80I1yUQBHzrtXPaQOP99d3ld3cpjBQpBKMjYfGV2hs4ONxXkQ==}
     engines: {node: '>= 18'}
     peerDependencies:
       '@mikro-orm/core': ^6.0.0
@@ -7656,7 +7656,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  better-auth-mikro-orm@0.1.1(@mikro-orm/core@6.4.1)(better-auth@1.1.3):
+  better-auth-mikro-orm@0.2.0(@mikro-orm/core@6.4.1)(better-auth@1.1.3):
     dependencies:
       '@mikro-orm/core': 6.4.1
       better-auth: 1.1.3


### PR DESCRIPTION
### Details

This PR updates `better-auth-mikro-orm` to latest stable version, which now includes support for 1:m references, no the app will not crash on user creation anymore.

### Changes

- [x] Bump `better-auth-mikro-orm`;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] I have added changesets <!-- optional -->
- [x] ~~I have brought tests <!-- if necessary -->~~
