### PR TITLE
chore(admin): Rewrite logout as action

### DIFF
--- a/.changeset/red-walls-wash.md
+++ b/.changeset/red-walls-wash.md
@@ -1,0 +1,5 @@
+---
+"eri": minor
+---
+
+Rewrite logout route as action

--- a/app/components/common/Sidebar.tsx
+++ b/app/components/common/Sidebar.tsx
@@ -1,6 +1,7 @@
+import {Slot} from "@radix-ui/react-slot"
 import {cn} from "@udecode/cn"
 import type {LucideIcon} from "lucide-react"
-import {type FC, Fragment, type ReactNode} from "react"
+import {type ComponentProps, type FC, Fragment, type ReactNode} from "react"
 import {Link} from "react-router"
 
 import {SheetClose, SheetContent, SheetTrigger} from "../ui/Sheet.jsx"
@@ -42,34 +43,76 @@ export const SidebarTrigger: FC<SidebarTriggerProps> = ({children}) => (
   <SheetTrigger className="post:hidden">{children}</SheetTrigger>
 )
 
-export interface SidebarItemProps {
-  icon: LucideIcon
+interface SidebarLinkItemProps extends ComponentProps<"a"> {
   href: string
+  children: ReactNode
+  asChild?: boolean
+}
+
+const SidebarLinkItem: FC<SidebarLinkItemProps> = ({asChild, ...props}) => {
+  const Element = asChild ? Slot : "a"
+
+  return <Element {...props} />
+}
+
+export interface SidebarButtonItemProps {
+  href?: never
+  children: ReactNode
+  asChild?: boolean
+}
+
+export const SidebarButtonItem: FC<SidebarButtonItemProps> = ({
+  asChild,
+  ...props
+}) => {
+  const Element = asChild ? Slot : "button"
+
+  return <Element {...props} />
+}
+
+export interface SidebarItemBaseProps {
+  icon: LucideIcon
   className?: string
   children: ReactNode
+  asChild?: boolean
 }
+
+export type SidebarItemProps = SidebarItemBaseProps &
+  (SidebarButtonItemProps | SidebarLinkItemProps)
 
 export const SidebarItem: FC<SidebarItemProps> = ({
   icon: Icon,
-  href,
   className,
-  children
-}) => (
-  <li
-    className={cn(
-      "py-2.5 post:px-5 laptop:px-0 first:pt-5 last:pb-5 w-full",
-      className
-    )}
-  >
-    <SheetClose asChild>
-      {/* FIXME: This component breaks in sidebar and I have no idea why */}
-      <Link to={href} className="flex gap-3 items-center">
-        <Icon size={20} />
+  href,
+  ...props
+}) => {
+  return (
+    <li
+      className={cn(
+        "py-2.5 post:px-5 laptop:px-0 first:pt-5 last:pb-5 w-full",
+        className
+      )}
+    >
+      <SheetClose asChild>
+        {/* FIXME: This component breaks in sidebar and I have no idea why */}
+        {/* <Link to={href} className="flex gap-3 items-center">
+          <Icon size={20} />
 
-        <span>{children}</span>
-      </Link>
-    </SheetClose>
-  </li>
-)
+          <Element {...props}>{children}</Element>
+        </Link> */}
+
+        <div className="flex gap-3 items-center">
+          <Icon size={20} />
+
+          {href ? (
+            <SidebarLinkItem {...props} href={href} />
+          ) : (
+            <SidebarButtonItem {...props} />
+          )}
+        </div>
+      </SheetClose>
+    </li>
+  )
+}
 
 export {Sheet as SidebarProvider} from "../ui/Sheet.jsx"

--- a/app/components/common/Sidebar.tsx
+++ b/app/components/common/Sidebar.tsx
@@ -94,13 +94,6 @@ export const SidebarItem: FC<SidebarItemProps> = ({
       )}
     >
       <SheetClose asChild>
-        {/* FIXME: This component breaks in sidebar and I have no idea why */}
-        {/* <Link to={href} className="flex gap-3 items-center">
-          <Icon size={20} />
-
-          <Element {...props}>{children}</Element>
-        </Link> */}
-
         <div className="flex gap-3 items-center">
           <Icon size={20} />
 

--- a/app/components/common/Sidebar.tsx
+++ b/app/components/common/Sidebar.tsx
@@ -2,7 +2,6 @@ import {Slot} from "@radix-ui/react-slot"
 import {cn} from "@udecode/cn"
 import type {LucideIcon} from "lucide-react"
 import {type ComponentProps, type FC, Fragment, type ReactNode} from "react"
-import {Link} from "react-router"
 
 import {SheetClose, SheetContent, SheetTrigger} from "../ui/Sheet.jsx"
 

--- a/app/routes/admin.logout.ts
+++ b/app/routes/admin.logout.ts
@@ -1,12 +1,11 @@
-import {data, replace} from "react-router"
+import {replace} from "react-router"
 
 import type {Route} from "./+types/admin.logout.js"
 
-// TODO: Rewrite as action
-export const loader = async ({
+export const action = async ({
   request,
   context: {auth}
-}: Route.LoaderArgs): Promise<never> => {
+}: Route.ActionArgs): Promise<never> => {
   const response = await auth.api.signOut({
     asResponse: true,
     headers: request.headers
@@ -14,11 +13,5 @@ export const loader = async ({
 
   throw replace("/admin", {
     headers: response.headers
-  })
-}
-
-export const action = (): never => {
-  throw data(null, {
-    status: 405
   })
 }

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -116,8 +116,10 @@ const AdminLayout: FC<Route.ComponentProps> = () => (
 
           <div className="flex flex-1" />
 
-          <SidebarItem icon={LogOut} href="/admin/logout">
-            Log out
+          <SidebarItem icon={LogOut} asChild>
+            <form action="/admin/logout" method="post">
+              <button type="submit">Log out</button>
+            </form>
           </SidebarItem>
         </Sidebar>
 

--- a/tests/node/routes/admin.logout.test.ts
+++ b/tests/node/routes/admin.logout.test.ts
@@ -3,16 +3,16 @@ import {expect} from "vitest"
 
 import {auth} from "../../../app/server/lib/auth/auth.js"
 import {test} from "../../fixtures/admin.js"
-import {createStubLoaderArgs} from "../../utils/createStubRouteArgs.js"
+import {createStubActionArgs} from "../../utils/createStubRouteArgs.js"
 import {getCookies} from "../../utils/getCookies.js"
 
-import {loader} from "../../../app/routes/admin.logout.js"
+import {action} from "../../../app/routes/admin.logout.js"
 
 test("throws redirect response", async ({admin}) => {
   expect.hasAssertions()
 
   try {
-    await loader(createStubLoaderArgs({request: admin.request}))
+    await action(createStubActionArgs({request: admin.request}))
   } catch (error) {
     const response = error as Response
 
@@ -25,7 +25,7 @@ test("resets session cookie", async ({admin}) => {
   expect.hasAssertions()
 
   try {
-    await loader(createStubLoaderArgs({request: admin.request}))
+    await action(createStubActionArgs({request: admin.request}))
   } catch (error) {
     const response = error as Response
 


### PR DESCRIPTION
### Details

This PR updates `/admin/logout` route to expose action instead of loader.

### Changes

- [x] Rewrite logout as action;
- [x] Add support for custom items in `Sidebar`;
- [x] Update sidebar to send a form to `/admin/logout` with `post` method;
- [x] Update tests for logout to use action instead of loader;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] I have added changesets <!-- optional -->
- [x] I have brought tests <!-- if necessary -->
